### PR TITLE
Pinned alignment and pinned multi-alignment

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -71,6 +71,7 @@ int main (int argc, char * const argv[]) {
     printf("Optimal local mapping:\n");
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
+
     
     gssw_graph_mapping* gmp = gssw_graph_trace_back_pinned (graph,
                                                             nodes[3],

--- a/src/example.c
+++ b/src/example.c
@@ -70,6 +70,19 @@ int main (int argc, char * const argv[]) {
 
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
+    
+    gssw_graph_mapping* gmp = gssw_graph_trace_back_pinned (graph,
+                                                            nodes[3],
+                                                            read_seq,
+                                                            strlen(read_seq),
+                                                            nt_table,
+                                                            mat,
+                                                            gap_open,
+                                                            gap_extension);
+    
+    gssw_print_graph_mapping(gmp, stdout);
+    gssw_graph_mapping_destroy(gmp);
+    
     // note that nodes which are referred to in this graph are destroyed as well
     gssw_graph_destroy(graph);
 

--- a/src/example.c
+++ b/src/example.c
@@ -68,6 +68,7 @@ int main (int argc, char * const argv[]) {
                                                     gap_open,
                                                     gap_extension);
 
+    printf("Optimal local mapping:\n");
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
     
@@ -80,8 +81,29 @@ int main (int argc, char * const argv[]) {
                                                             gap_open,
                                                             gap_extension);
     
+    printf("Optimal pinned mapping:\n");
     gssw_print_graph_mapping(gmp, stdout);
     gssw_graph_mapping_destroy(gmp);
+    
+    gssw_graph_mapping** gmps = gssw_graph_trace_back_pinned_multi (graph,
+                                                                    nodes[3],
+                                                                    3,
+                                                                    read_seq,
+                                                                    strlen(read_seq),
+                                                                    nt_table,
+                                                                    mat,
+                                                                    gap_open,
+                                                                    gap_extension);
+    
+    printf("Best three pinned mappings:\n");
+    gssw_print_graph_mapping(gmps[0], stdout);
+    gssw_print_graph_mapping(gmps[1], stdout);
+    gssw_print_graph_mapping(gmps[2], stdout);
+    gssw_graph_mapping_destroy(gmps[0]);
+    gssw_graph_mapping_destroy(gmps[1]);
+    gssw_graph_mapping_destroy(gmps[2]);
+
+    free(gmps);
     
     // note that nodes which are referred to in this graph are destroyed as well
     gssw_graph_destroy(graph);

--- a/src/example.c
+++ b/src/example.c
@@ -85,9 +85,10 @@ int main (int argc, char * const argv[]) {
     gssw_print_graph_mapping(gmp, stdout);
     gssw_graph_mapping_destroy(gmp);
     
+    int num_alts = 15;
     gssw_graph_mapping** gmps = gssw_graph_trace_back_pinned_multi (graph,
                                                                     nodes[3],
-                                                                    3,
+                                                                    num_alts,
                                                                     read_seq,
                                                                     strlen(read_seq),
                                                                     nt_table,
@@ -95,13 +96,12 @@ int main (int argc, char * const argv[]) {
                                                                     gap_open,
                                                                     gap_extension);
     
-    printf("Best three pinned mappings:\n");
-    gssw_print_graph_mapping(gmps[0], stdout);
-    gssw_print_graph_mapping(gmps[1], stdout);
-    gssw_print_graph_mapping(gmps[2], stdout);
-    gssw_graph_mapping_destroy(gmps[0]);
-    gssw_graph_mapping_destroy(gmps[1]);
-    gssw_graph_mapping_destroy(gmps[2]);
+    printf("Best %d pinned mappings:\n", num_alts);
+    int j;
+    for (j = 0; j < num_alts; j++) {
+        gssw_print_graph_mapping(gmps[j], stdout);
+        gssw_graph_mapping_destroy(gmps[j]);
+    }
 
     free(gmps);
     

--- a/src/example_adj.c
+++ b/src/example_adj.c
@@ -23,7 +23,7 @@ void remove_phred_offset(char* qual_str) {
 //	Align a pair of genome sequences.
 int main (int argc, char * const argv[]) {
     // default parameters for genome sequence alignment
-    int8_t match = 2, mismatch = 2, gap_open = 3, gap_extension = 1;
+    int8_t match = 1, mismatch = 4, gap_open = 6, gap_extension = 1;
     // from Mengyao's example about the importance of using all three matrices in traceback.
     // int32_t l, m, k, match = 2, mismatch = 1, gap_open = 2, gap_extension = 1;
     
@@ -89,7 +89,8 @@ int main (int argc, char * const argv[]) {
                                                              adj_mat,
                                                              gap_open,
                                                              gap_extension);
-
+    
+    printf("Optimal local mapping:\n");
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
     
@@ -103,8 +104,31 @@ int main (int argc, char * const argv[]) {
                                                                      gap_open,
                                                                      gap_extension);
     
+    printf("Optimal pinned mapping:\n");
     gssw_print_graph_mapping(gmp, stdout);
     gssw_graph_mapping_destroy(gmp);
+    
+    int num_alts = 30;
+    gssw_graph_mapping** gmps = gssw_graph_trace_back_pinned_qual_adj_multi (graph,
+                                                                             nodes[3],
+                                                                             num_alts,
+                                                                             read_seq,
+                                                                             read_qual,
+                                                                             strlen(read_seq),
+                                                                             nt_table,
+                                                                             adj_mat,
+                                                                             gap_open,
+                                                                             gap_extension);
+    
+    printf("Best %d pinned mappings:\n", num_alts);
+    int j;
+    for (j = 0; j < num_alts; j++) {
+        gssw_print_graph_mapping(gmps[j], stdout);
+        gssw_graph_mapping_destroy(gmps[j]);
+    }
+    
+    free(gmps);
+    
     // note that nodes which are referred to in this graph are destroyed as well
     gssw_graph_destroy(graph);
 

--- a/src/example_adj.c
+++ b/src/example_adj.c
@@ -92,6 +92,19 @@ int main (int argc, char * const argv[]) {
 
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
+    
+    gssw_graph_mapping* gmp = gssw_graph_trace_back_pinned_qual_adj (graph,
+                                                                     nodes[3],
+                                                                     read_seq,
+                                                                     read_qual,
+                                                                     strlen(read_seq),
+                                                                     nt_table,
+                                                                     adj_mat,
+                                                                     gap_open,
+                                                                     gap_extension);
+    
+    gssw_print_graph_mapping(gmp, stdout);
+    gssw_graph_mapping_destroy(gmp);
     // note that nodes which are referred to in this graph are destroyed as well
     gssw_graph_destroy(graph);
 

--- a/src/gssw.c
+++ b/src/gssw.c
@@ -2728,7 +2728,12 @@ gssw_graph_mapping** gssw_graph_trace_back_internal (gssw_graph* graph,
         
         // Get score that will be present in the matrix cell
         // note: can ignore the matrix field in the deflection because it is always safe to start in H matrix
-        if (score_is_byte) {
+        if (readEnd < 0 || refEnd < 0) {
+            // edge case that occurs when then entire matrix is 0s (then there is no max score so the initial values for
+            // refEnd and readEnd are retained)
+            score = 0;
+        }
+        else if (score_is_byte) {
             uint8_t* mH = (uint8_t*) n->alignment->mH;
             score = mH[readLen * refEnd + readEnd];
         }

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -197,6 +197,41 @@ typedef struct {
     gssw_graph_cigar cigar;
 } gssw_graph_mapping;
 
+// matrices in the SSW algorithm
+typedef enum gssw_matrix_t {Match, ReadGap, RefGap} gssw_matrix_t;
+
+// position in the DP structure
+typedef struct {
+    int32_t read_pos;
+    int32_t ref_pos;
+    gssw_matrix_t from_matrix;
+    gssw_matrix_t to_matrix;
+    gssw_node* from_node;
+    gssw_node* to_node;
+} gssw_trace_back_deflection;
+
+// an array of positions where the traceback follows a suboptimal alignment
+typedef struct {
+    int16_t score;
+    gssw_trace_back_deflection* deflections; // first deflection should be the start coordinates
+    int32_t num_deflections;
+} gssw_alternate_alignment_ends;
+
+// a linked list of top alternate alignments
+typedef struct gssw_multi_align_stack_node {
+    gssw_alternate_alignment_ends* alt_alignment;
+    struct gssw_multi_align_stack_node* next;
+    struct gssw_multi_align_stack_node* prev;
+} gssw_multi_align_stack_node;
+
+typedef struct {
+    int32_t current_size;
+    int32_t capacity;
+    gssw_multi_align_stack_node* bottom_scoring;
+    gssw_multi_align_stack_node* top_scoring;
+} gssw_multi_align_stack;
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -367,39 +402,13 @@ void gssw_graph_print_stderr(gssw_graph* graph);
     @param alignment  Alignment structure.
     @param end        Alignment ending position.
 */
-gssw_cigar* gssw_alignment_trace_back_byte (gssw_align* alignment,
-                                            uint16_t* score,
-                                            int32_t* refEnd,
-                                            int32_t* readEnd,
-                                            int32_t* refGapFlag,
-                                            int32_t* readGapFlag,
-                                            const char* ref,
-                                            int32_t refLen,
-                                            const char* read,
-                                            int8_t* qual_num,
-                                            int32_t readLen,
-                                            int8_t* nt_table,
-                                            int8_t* score_matrix,
-                                            uint8_t gap_open,
-                                            uint8_t gap_extension);
-
-gssw_cigar* gssw_alignment_trace_back_word (gssw_align* alignment,
-                                            uint16_t* score,
-                                            int32_t* refEnd,
-                                            int32_t* readEnd,
-                                            int32_t* refGapFlag,
-                                            int32_t* readGapFlag,
-                                            const char* ref,
-                                            int32_t refLen,
-                                            const char* read,
-                                            int8_t* qual_num,
-                                            int32_t readLen,
-                                            int8_t* nt_table,
-                                            int8_t* score_matrix,
-                                            uint8_t gap_open,
-                                            uint8_t gap_extension);
-
-gssw_cigar* gssw_alignment_trace_back (gssw_align* alignment,
+    
+    
+gssw_cigar* gssw_alignment_trace_back (gssw_node* node,
+                                       gssw_multi_align_stack* alt_alignment_stack,
+                                       gssw_alternate_alignment_ends* alignment_deflections,
+                                       int32_t* deflection_idx,
+                                       int32_t final_traceback,
                                        uint16_t* score,
                                        int32_t* refEnd,
                                        int32_t* readEnd,
@@ -414,6 +423,46 @@ gssw_cigar* gssw_alignment_trace_back (gssw_align* alignment,
                                        int8_t* score_matrix,
                                        uint8_t gap_open,
                                        uint8_t gap_extension);
+    
+gssw_cigar* gssw_alignment_trace_back_byte (gssw_node* node,
+                                            gssw_multi_align_stack* alt_alignment_stack,
+                                            gssw_alternate_alignment_ends* alignment_deflections,
+                                            int32_t* deflection_idx,
+                                            int32_t final_traceback,
+                                            uint16_t* score,
+                                            int32_t* refEnd,
+                                            int32_t* readEnd,
+                                            int32_t* refGapFlag,
+                                            int32_t* readGapFlag,
+                                            const char* ref,
+                                            int32_t refLen,
+                                            const char* read,
+                                            int8_t* qual_num,
+                                            int32_t readLen,
+                                            int8_t* nt_table,
+                                            int8_t* score_matrix,
+                                            uint8_t gap_open,
+                                            uint8_t gap_extension);
+
+gssw_cigar* gssw_alignment_trace_back_word (gssw_node* node,
+                                            gssw_multi_align_stack* alt_alignment_stack,
+                                            gssw_alternate_alignment_ends* alignment_deflections,
+                                            int32_t* deflection_idx,
+                                            int32_t final_traceback,
+                                            uint16_t* score,
+                                            int32_t* refEnd,
+                                            int32_t* readEnd,
+                                            int32_t* refGapFlag,
+                                            int32_t* readGapFlag,
+                                            const char* ref,
+                                            int32_t refLen,
+                                            const char* read,
+                                            int8_t* qual_num,
+                                            int32_t readLen,
+                                            int8_t* nt_table,
+                                            int8_t* score_matrix,
+                                            uint8_t gap_open,
+                                            uint8_t gap_extension);
 
 // Compute and return the traceback from a graph for which the alignment DP has been performed.
 gssw_graph_mapping* gssw_graph_trace_back (gssw_graph* graph,
@@ -454,6 +503,31 @@ gssw_graph_mapping* gssw_graph_trace_back_pinned_qual_adj (gssw_graph* graph,
                                                            uint8_t gap_open,
                                                            uint8_t gap_extension);
 
+// Computes an arbitrary number of highest scoring tracebacks ending with the final character of the
+// read aligned to the final character of a given node
+gssw_graph_mapping** gssw_graph_trace_back_pinned_multi (gssw_graph* graph,
+                                                         gssw_node* pinned_node,
+                                                         int32_t num_tracebacks,
+                                                         const char* read,
+                                                         int32_t readLen,
+                                                         int8_t* nt_table,
+                                                         int8_t* score_matrix,
+                                                         uint8_t gap_open,
+                                                         uint8_t gap_extension);
+
+gssw_graph_mapping** gssw_graph_trace_back_pinned_qual_adj_multi (gssw_graph* graph,
+                                                                  gssw_node* pinned_node,
+                                                                  int32_t num_tracebacks,
+                                                                  const char* read,
+                                                                  const char* qual,
+                                                                  int32_t readLen,
+                                                                  int8_t* nt_table,
+                                                                  int8_t* adj_score_matrix,
+                                                                  uint8_t gap_open,
+                                                                  uint8_t gap_extension);
+
+
+    
 /*! @function         Return 1 if the alignment is in 16/128bit (byte sized) or 0 if word-sized.
     @param alignment  Alignment structure.
 */
@@ -610,7 +684,27 @@ int8_t* gssw_dna_scaled_adjusted_qual_matrix(int8_t max_score, uint8_t max_qual,
                                              int8_t* gap_extend_out, int8_t match_score, int8_t mismatch_score,
                                              double gc_content, double tol);
 
+    
+/* Initializes a stack to keep track of top alternate alignments (up to the capacity) in score sorted order */
+gssw_multi_align_stack* gssw_new_multi_align_stack(int32_t capacity);
 
+/* Constructor for a node on the stack */
+gssw_multi_align_stack_node* gssw_new_multi_align_stack_node(gssw_alternate_alignment_ends* alignment_suffix, int16_t score,
+                                                             int32_t read_pos, int32_t ref_pos, gssw_node* from_node,
+                                                             gssw_node* to_node, gssw_matrix_t from_matrix, gssw_matrix_t to_matrix);
+
+/* Destructor for a node on the stack */
+void gssw_delete_multi_align_stack_node(gssw_multi_align_stack_node* stack_node);
+
+/* Adds an alignment onto the stack if there is room or if it is higher scoring than any of the alignments currently in it */
+void gssw_add_alignment(gssw_multi_align_stack* stack, gssw_alternate_alignment_ends* alignment_suffix, int16_t score,
+                        int32_t read_pos, int32_t ref_pos, gssw_node* from_node, gssw_node* to_node, gssw_matrix_t from_matrix,
+                        gssw_matrix_t to_matrix);
+    
+/* Retuns the lowest score of an alternate alignment in the stack */
+int16_t gssw_min_alt_alignment_score(gssw_multi_align_stack* stack);
+    
+    
 #ifdef __cplusplus
 }
 #endif	// __cplusplus

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -433,6 +433,27 @@ gssw_graph_mapping* gssw_graph_trace_back_qual_adj (gssw_graph* graph,
                                                     uint8_t gap_open,
                                                     uint8_t gap_extension);
 
+// Computes the traceback ending with the final character of the read aligned to the final character
+// of a given node
+gssw_graph_mapping* gssw_graph_trace_back_pinned (gssw_graph* graph,
+                                                  gssw_node* pinned_node,
+                                                  const char* read,
+                                                  int32_t readLen,
+                                                  int8_t* nt_table,
+                                                  int8_t* score_matrix,
+                                                  uint8_t gap_open,
+                                                  uint8_t gap_extension);
+    
+gssw_graph_mapping* gssw_graph_trace_back_pinned_qual_adj (gssw_graph* graph,
+                                                           gssw_node* pinned_node,
+                                                           const char* read,
+                                                           const char* qual,
+                                                           int32_t readLen,
+                                                           int8_t* nt_table,
+                                                           int8_t* adj_score_matrix,
+                                                           uint8_t gap_open,
+                                                           uint8_t gap_extension);
+
 /*! @function         Return 1 if the alignment is in 16/128bit (byte sized) or 0 if word-sized.
     @param alignment  Alignment structure.
 */

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -687,6 +687,9 @@ int8_t* gssw_dna_scaled_adjusted_qual_matrix(int8_t max_score, uint8_t max_qual,
     
 /* Initializes a stack to keep track of top alternate alignments (up to the capacity) in score sorted order */
 gssw_multi_align_stack* gssw_new_multi_align_stack(int32_t capacity);
+    
+/* Destructor for the stack */
+void gssw_delete_multi_align_stack(gssw_multi_align_stack* stack);
 
 /* Constructor for a node on the stack */
 gssw_multi_align_stack_node* gssw_new_multi_align_stack_node(gssw_alternate_alignment_ends* alignment_suffix, int16_t score,


### PR DESCRIPTION
Added new functions to perform alignment with a "pinned node", where the end of the read must be aligned to the end of the node. This is intended to be used in the MEM threading routine in vg. I also added the ability to return an arbitrary number of alternate pinned alignments in addition to the optimum. These are returned in descending score order from the optimum.
