### PR TITLE
Add tests, software matrix filler, and improved E and F calculation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ EXE=gssw_example
 EXEADJ=gssw_example_adj
 EXETEST=gssw_test
 
-.PHONY:all clean cleanlocal
+.PHONY:all clean cleanlocal test
 
 all:$(BIN_DIR)/$(EXE) $(BIN_DIR)/$(EXEADJ) $(BIN_DIR)/$(EXETEST) $(LIB_DIR)/libgssw.a
 
@@ -34,6 +34,9 @@ $(OBJ_DIR)/$(OBJ):$(SRC_DIR)/gssw.h $(SRC_DIR)/gssw.c
 $(LIB_DIR)/libgssw.a:$(OBJ_DIR)/$(OBJ)
 	@mkdir -p $(@D)
 	ar rvs $@ $<
+	
+test:$(BIN_DIR)/$(EXETEST)
+	$(BIN_DIR)/$(EXETEST)
 
 cleanlocal:
 	$(RM) -r lib/

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ $(BIN_DIR)/$(EXETEST):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/gssw_test.c
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(SRC_DIR)/gssw_test.c -o $@ $< -lm -lz
 
-$(OBJ_DIR)/$(OBJ):$(SRC_DIR)/gssw.h
+$(OBJ_DIR)/$(OBJ):$(SRC_DIR)/gssw.h $(SRC_DIR)/gssw.c
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c -o $@ $(SRC_DIR)/gssw.c
 

--- a/Makefile
+++ b/Makefile
@@ -7,27 +7,32 @@ LIB_DIR:=lib
 
 OBJ=gssw.o
 EXE=gssw_example
-EXEADJ= gssw_example_adj
+EXEADJ=gssw_example_adj
+EXETEST=gssw_test
 
-.PHONY:all clean cleanlocal pre
+.PHONY:all clean cleanlocal
 
-all:$(BIN_DIR)/$(EXE) $(BIN_DIR)/$(EXEADJ) $(LIB_DIR)/libgssw.a
+all:$(BIN_DIR)/$(EXE) $(BIN_DIR)/$(EXEADJ) $(BIN_DIR)/$(EXETEST) $(LIB_DIR)/libgssw.a
 
-pre:
-	mkdir -p bin
-	mkdir -p obj
-	mkdir -p lib
-
-$(BIN_DIR)/$(EXE):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/example.c pre
+$(BIN_DIR)/$(EXE):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/example.c
+	# Make dest directory
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(SRC_DIR)/example.c -o $@ $< -lm -lz
 
-$(BIN_DIR)/$(EXEADJ):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/example_adj.c pre
+$(BIN_DIR)/$(EXEADJ):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/example_adj.c
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(SRC_DIR)/example_adj.c -o $@ $< -lm -lz
 
-$(OBJ_DIR)/$(OBJ):$(SRC_DIR)/gssw.h pre
+$(BIN_DIR)/$(EXETEST):$(OBJ_DIR)/$(OBJ) $(SRC_DIR)/gssw_test.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) $(SRC_DIR)/gssw_test.c -o $@ $< -lm -lz
+
+$(OBJ_DIR)/$(OBJ):$(SRC_DIR)/gssw.h
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c -o $@ $(SRC_DIR)/gssw.c
 
-$(LIB_DIR)/libgssw.a:$(OBJ_DIR)/$(OBJ) pre
+$(LIB_DIR)/libgssw.a:$(OBJ_DIR)/$(OBJ)
+	@mkdir -p $(@D)
 	ar rvs $@ $<
 
 cleanlocal:
@@ -36,5 +41,7 @@ cleanlocal:
 	$(RM) -r obj/
 
 clean:cleanlocal
+
+
 
 

--- a/src/example.c
+++ b/src/example.c
@@ -26,6 +26,8 @@ int main (int argc, char * const argv[]) {
     char *ref_seq_4 = argv[4];
     char *read_seq = argv[5];
 
+    gssw_sse2_disable();
+
 	/* This table is used to transform nucleotide letters into numbers. */
     int8_t* nt_table = gssw_create_nt_table();
     

--- a/src/example.c
+++ b/src/example.c
@@ -1,8 +1,8 @@
 /*	example.c
  *	This is a simple example to show you how to use the SSW C library.
  *	To run this example:
- *	1) gcc -Wall -lz ssw.c example.c
- *	2) ./a.out
+ *	1) make
+ *	2) bin/gssw_example GAT TT T ACA GATTACA
  *	Created by Mengyao Zhao on 07/31/12.
  */
 

--- a/src/gssw.c
+++ b/src/gssw.c
@@ -31,8 +31,8 @@
  *
  *  Created by Mengyao Zhao on 6/22/10.
  *  Copyright 2010 Boston College. All rights reserved.
- *	Version 0.1.4
- *	Last revision by Erik Garrison 01/02/2014
+ *    Version 0.1.4
+ *    Last revision by Erik Garrison 01/02/2014
  *
  */
 #include <emmintrin.h>
@@ -95,26 +95,26 @@ void gssw_sse2_enable() {
 __m128i* gssw_qP_byte (const int8_t* read_num,
                        const int8_t* mat,
                        const int32_t readLen,
-                       const int32_t n,	/* the edge length of the squre matrix mat */
+                       const int32_t n,    /* the edge length of the squre matrix mat */
                        uint8_t bias,
                        int8_t start_full_length_bonus,
                        int8_t end_full_length_bonus) {
 
-	int32_t segLen = (readLen + 15) / 16; /* Split the 128 bit register into 16 pieces.
-								     Each piece is 8 bit. Split the read into 16 segments.
-								     Calculate 16 segments in parallel.
-								     This holds the number of segments needed to fit the read.
-								   */
-	__m128i* vProfile = (__m128i*)malloc(n * segLen * sizeof(__m128i));
-	int8_t* t = (int8_t*)vProfile; // This points to each byte in the profile vector, one at a time
-	// nt tracks the nucleotide we're computing the profile for. We do each possible character.
-	// i tracks which swizzled register we're working on
-	// j tracks the character in the read we're working on
-	// segNum counts which of the 16 read segments we're working on, each of which gets its own byte in each swizzled register
-	int32_t nt, i, j, segNum; 
+    int32_t segLen = (readLen + 15) / 16; /* Split the 128 bit register into 16 pieces.
+                                     Each piece is 8 bit. Split the read into 16 segments.
+                                     Calculate 16 segments in parallel.
+                                     This holds the number of segments needed to fit the read.
+                                   */
+    __m128i* vProfile = (__m128i*)malloc(n * segLen * sizeof(__m128i));
+    int8_t* t = (int8_t*)vProfile; // This points to each byte in the profile vector, one at a time
+    // nt tracks the nucleotide we're computing the profile for. We do each possible character.
+    // i tracks which swizzled register we're working on
+    // j tracks the character in the read we're working on
+    // segNum counts which of the 16 read segments we're working on, each of which gets its own byte in each swizzled register
+    int32_t nt, i, j, segNum; 
     
-	/* Generate query profile rearrange query sequence & calculate the weight of match/mismatch */
-	for (nt = 0; LIKELY(nt < n); nt ++) {
+    /* Generate query profile rearrange query sequence & calculate the weight of match/mismatch */
+    for (nt = 0; LIKELY(nt < n); nt ++) {
         
         // special logic for first vector to add bonus for full length left alignment
         if (segLen > 0) {
@@ -134,24 +134,24 @@ __m128i* gssw_qP_byte (const int8_t* read_num,
             }
         }
         
-		for (i = 1; i < segLen; i ++) {
-			j = i;
-			for (segNum = 0; LIKELY(segNum < 16) ; segNum ++) {
-			    // Now handle all the vectors after the first
+        for (i = 1; i < segLen; i ++) {
+            j = i;
+            for (segNum = 0; LIKELY(segNum < 16) ; segNum ++) {
+                // Now handle all the vectors after the first
                 *t = j>= readLen ? bias : mat[nt * n + read_num[j]] + bias + (j == readLen - 1 ? end_full_length_bonus : 0);
                 t++;
-				j += segLen;
-			}
-		}
-	}
-	return vProfile;
+                j += segLen;
+            }
+        }
+    }
+    return vProfile;
 }
 
 __m128i* gssw_adj_qP_byte (const int8_t* read_num,
                            const int8_t* qual,
                            const int8_t* adj_mat,
                            const int32_t readLen,
-                           const int32_t n,	/* the edge length of the squre matrix mat */
+                           const int32_t n,    /* the edge length of the squre matrix mat */
                            uint8_t bias,
                            int8_t start_full_length_bonus,
                            int8_t end_full_length_bonus) {
@@ -332,13 +332,13 @@ uint8_t max_byte(uint8_t a, uint8_t b) {
  * Used for computing known good alingments, for testing.
  */
 gssw_alignment_end* gssw_sw_software_byte (const int8_t* ref,
-                                           int8_t ref_dir,	// 0: forward ref; 1: reverse ref
+                                           int8_t ref_dir,    // 0: forward ref; 1: reverse ref
                                            int32_t refLen,
                                            int32_t readLen,
                                            const uint8_t weight_gapO, /* will be used as - */
                                            const uint8_t weight_gapE, /* will be used as - */
                                            __m128i* vProfile,
-                                           uint8_t terminate,	/* the best alignment score: used to terminate
+                                           uint8_t terminate,    /* the best alignment score: used to terminate
                                                                    the matrix calculation when locating the
                                                                    alignment beginning point. If this score
                                                                    is set to 0, it will not be used */
@@ -349,9 +349,9 @@ gssw_alignment_end* gssw_sw_software_byte (const int8_t* ref,
                                            
     
                                        
-    uint8_t max = 0;		                     /* the max alignment score */
-	int32_t end_read = readLen - 1;
-	int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
+    uint8_t max = 0;                             /* the max alignment score */
+    int32_t end_read = readLen - 1;
+    int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
 
     // We need to make sure out matrices are sized to the nearest 16, so pad the read length.
     int32_t padded_read_length = ((readLen + 15) / 16) * 16;
@@ -419,48 +419,48 @@ gssw_alignment_end* gssw_sw_software_byte (const int8_t* ref,
     
     int32_t begin = 0, end = refLen, step = 1;
 
-	/* outer loop to process the reference sequence */
-	if (ref_dir == 1) {
-		begin = refLen - 1;
-		end = -1;
-		step = -1;
-	}
-	int32_t i;
-	for (i = begin; LIKELY(i != end); i += step) {
-	    // For each column i in the DP matrices (running in the appropriate direction)
-	    
-	    // We don't need the previous F column.
-	    // But we do need to push the current H and E columns to the previous ones.
-	    // We use a double buffering settup so we don't need to malloc and free and copy stuff.
-	    // By working with a previous and next column, we don't need to do anything fancy to support the flipable ref_dir.
-	    pv = pvHLoad;
-	    pvHLoad = pvHStore;
-	    pvHStore = pv;
-	    pv = pvELoad;
-	    pvELoad = pvEStore;
-	    pvEStore = pv;
-	    
-	    int32_t j;
-	    for (j = 0; j < readLen; j++) {
-	        // For each row j in the DP matrices (running top to bottom)
-	        
-	        // Set the gap-in-read matrix (E) based on previous E and previous H
-	        uint8_t readGapOpenScore = subs_byte(pvHLoad[j], weight_gapO);
-	        uint8_t readGapExtendScore = subs_byte(pvELoad[j], weight_gapE);
-	        pvEStore[j] = max_byte(readGapOpenScore, readGapExtendScore);
-	        
-	        uint8_t refGapOpenScore = 0;
-	        uint8_t refGapExtendScore = 0;
-	        if (j == 0) {
-	            // We can only end in a gap in the reference on the first read character with negative score.
-	            // But we saturate that out to 0.
-	            pvFStore[j] = subs_byte(0, weight_gapO);
-	        } else {
-	            // Set the gap-in-ref matrix (F) based on previous slot in current F and in current H
-	            refGapOpenScore = subs_byte(pvHStore[j-1], weight_gapO);
-	            refGapExtendScore = subs_byte(pvFStore[j-1], weight_gapE);
-	            pvFStore[j] = max_byte(refGapOpenScore, refGapExtendScore);
-	        }
+    /* outer loop to process the reference sequence */
+    if (ref_dir == 1) {
+        begin = refLen - 1;
+        end = -1;
+        step = -1;
+    }
+    int32_t i;
+    for (i = begin; LIKELY(i != end); i += step) {
+        // For each column i in the DP matrices (running in the appropriate direction)
+        
+        // We don't need the previous F column.
+        // But we do need to push the current H and E columns to the previous ones.
+        // We use a double buffering settup so we don't need to malloc and free and copy stuff.
+        // By working with a previous and next column, we don't need to do anything fancy to support the flipable ref_dir.
+        pv = pvHLoad;
+        pvHLoad = pvHStore;
+        pvHStore = pv;
+        pv = pvELoad;
+        pvELoad = pvEStore;
+        pvEStore = pv;
+        
+        int32_t j;
+        for (j = 0; j < readLen; j++) {
+            // For each row j in the DP matrices (running top to bottom)
+            
+            // Set the gap-in-read matrix (E) based on previous E and previous H
+            uint8_t readGapOpenScore = subs_byte(pvHLoad[j], weight_gapO);
+            uint8_t readGapExtendScore = subs_byte(pvELoad[j], weight_gapE);
+            pvEStore[j] = max_byte(readGapOpenScore, readGapExtendScore);
+            
+            uint8_t refGapOpenScore = 0;
+            uint8_t refGapExtendScore = 0;
+            if (j == 0) {
+                // We can only end in a gap in the reference on the first read character with negative score.
+                // But we saturate that out to 0.
+                pvFStore[j] = subs_byte(0, weight_gapO);
+            } else {
+                // Set the gap-in-ref matrix (F) based on previous slot in current F and in current H
+                refGapOpenScore = subs_byte(pvHStore[j-1], weight_gapO);
+                refGapExtendScore = subs_byte(pvFStore[j-1], weight_gapE);
+                pvFStore[j] = max_byte(refGapOpenScore, refGapExtendScore);
+            }
 
             // What score are we adding to with a match?
             // If there's nowhere to come from it's 0.
@@ -476,57 +476,57 @@ gssw_alignment_end* gssw_sw_software_byte (const int8_t* ref,
             uint8_t matchScore = adds_byte(matchFrom, profileScore);
             // Subtract out the bias that the profile score had on it.
             matchScore = subs_byte(matchScore, bias);
-	        
-	        // Set the normal (H) matrix based on current E, current F, and match/mismatch score
-	        pvHStore[j] = max_byte(max_byte(pvEStore[j], pvFStore[j]), matchScore);
-	        
+            
+            // Set the normal (H) matrix based on current E, current F, and match/mismatch score
+            pvHStore[j] = max_byte(max_byte(pvEStore[j], pvFStore[j]), matchScore);
+            
 #ifdef DEBUG_SOFTWARE_FILL
-	        // Dump the matrix as we fill it.
-	        fprintf(stderr, "(%d, %d): Read O:%hhu E:%hhu Ref O:%hhu E:%hhu Match:%hhu+%hhu-%hhu=%hhu\n",
-	            i, j,
-	            readGapOpenScore, readGapExtendScore,
-	            refGapOpenScore, refGapExtendScore,
-	            matchFrom, profileScore, bias, matchScore);
+            // Dump the matrix as we fill it.
+            fprintf(stderr, "(%d, %d): Read O:%hhu E:%hhu Ref O:%hhu E:%hhu Match:%hhu+%hhu-%hhu=%hhu\n",
+                i, j,
+                readGapOpenScore, readGapExtendScore,
+                refGapOpenScore, refGapExtendScore,
+                matchFrom, profileScore, bias, matchScore);
 #endif
-	    
-	        // Set the running max
-	        if (pvHStore[j] > max) {
-	            max = pvHStore[j];
-	            end_ref = i;
-	            end_read = j;
-	        }
-	        
-	        // Copy from columns to matrices
-	        mH[i * readLen + j] = pvHStore[j];
-	        mE[i * readLen + j] = pvEStore[j];
-	        mF[i * readLen + j] = pvFStore[j];
-	    }
-	}
-	
-	// Reswizzle seeds
-	swizzle_byte(pvEStore, padded_read_length);
-	swizzle_byte(pvHStore, padded_read_length);
-	
-	// Save seeds.
+        
+            // Set the running max
+            if (pvHStore[j] > max) {
+                max = pvHStore[j];
+                end_ref = i;
+                end_read = j;
+            }
+            
+            // Copy from columns to matrices
+            mH[i * readLen + j] = pvHStore[j];
+            mE[i * readLen + j] = pvEStore[j];
+            mF[i * readLen + j] = pvFStore[j];
+        }
+    }
+    
+    // Reswizzle seeds
+    swizzle_byte(pvEStore, padded_read_length);
+    swizzle_byte(pvHStore, padded_read_length);
+    
+    // Save seeds.
     memcpy(alignment->seed.pvE,      pvEStore, padded_read_length);
     memcpy(alignment->seed.pvHStore, pvHStore, padded_read_length);
 
     // Clean up all the buffers
-	free(pvHLoad);
+    free(pvHLoad);
     free(pvHStore);
     free(pvELoad);
     free(pvEStore);
     // No pvFLoad.
     free(pvFStore);
 
-	/* Find the most possible 2nd best alignment. */
-	// TODO: this only does the best alignment???
-	gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
-	bests[0].score = max + bias >= 255 ? 255 : max;
-	bests[0].ref = end_ref;
-	bests[0].read = end_read;
+    /* Find the most possible 2nd best alignment. */
+    // TODO: this only does the best alignment???
+    gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
+    bests[0].score = max + bias >= 255 ? 255 : max;
+    bests[0].ref = end_ref;
+    bests[0].read = end_read;
 
-	return bests;
+    return bests;
 }
 
 /* To determine the maximum values within each vector, rather than between vectors. */
@@ -552,13 +552,13 @@ gssw_alignment_end* gssw_sw_software_byte (const int8_t* ref,
    The returned positions are 0-based.
  */
 gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
-                                       int8_t ref_dir,	// 0: forward ref; 1: reverse ref
+                                       int8_t ref_dir,    // 0: forward ref; 1: reverse ref
                                        int32_t refLen,
                                        int32_t readLen,
                                        const uint8_t weight_gapO, /* will be used as - */
                                        const uint8_t weight_gapE, /* will be used as - */
                                        __m128i* vProfile,
-                                       uint8_t terminate,	/* the best alignment score: used to terminate
+                                       uint8_t terminate,    /* the best alignment score: used to terminate
                                                                the matrix calculation when locating the
                                                                alignment beginning point. If this score
                                                                is set to 0, it will not be used */
@@ -567,13 +567,13 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
                                        gssw_align* alignment, /* to save seed and matrix */
                                        const gssw_seed* seed) {     /* to seed the alignment */
 
-	uint8_t max = 0;		                     /* the max alignment score */
-	int32_t end_read = readLen - 1;
-	int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
-	int32_t segLen = (readLen + 15) / 16; /* number of segment */
+    uint8_t max = 0;                             /* the max alignment score */
+    int32_t end_read = readLen - 1;
+    int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
+    int32_t segLen = (readLen + 15) / 16; /* number of segment */
 
     /* Initialize buffers used in alignment */
-	__m128i* pvHStore;
+    __m128i* pvHStore;
     __m128i* pvHLoad;
     __m128i* pvHmax;
     __m128i* pvE; // TODO: appears redundant with pvEStore
@@ -626,57 +626,57 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
     /* Record that we have done a byte-order alignment */
     alignment->is_byte = 1;
 
-	/* Define 16 byte 0 vector. */
-	__m128i vZero = _mm_set1_epi32(0);
+    /* Define 16 byte 0 vector. */
+    __m128i vZero = _mm_set1_epi32(0);
 
     /* Used for iteration */
-	int32_t i, j;
+    int32_t i, j;
 
     /* 16 byte insertion begin vector */
-	__m128i vGapO = _mm_set1_epi8(weight_gapO);
+    __m128i vGapO = _mm_set1_epi8(weight_gapO);
 
-	/* 16 byte insertion extension vector */
-	__m128i vGapE = _mm_set1_epi8(weight_gapE);
+    /* 16 byte insertion extension vector */
+    __m128i vGapE = _mm_set1_epi8(weight_gapE);
 
-	/* 16 byte bias vector */
-	__m128i vBias = _mm_set1_epi8(bias);
+    /* 16 byte bias vector */
+    __m128i vBias = _mm_set1_epi8(bias);
 
-	__m128i vMaxScore = vZero; /* Trace the highest score of the whole SW matrix. */
-	__m128i vMaxMark = vZero; /* Trace the highest score till the previous column. */
-	__m128i vTemp;
-	int32_t begin = 0, end = refLen, step = 1;
+    __m128i vMaxScore = vZero; /* Trace the highest score of the whole SW matrix. */
+    __m128i vMaxMark = vZero; /* Trace the highest score till the previous column. */
+    __m128i vTemp;
+    int32_t begin = 0, end = refLen, step = 1;
 
-	/* outer loop to process the reference sequence */
-	if (ref_dir == 1) {
-		begin = refLen - 1;
-		end = -1;
-		step = -1;
-	}
-	for (i = begin; LIKELY(i != end); i += step) {
-		int32_t cmp;
-		__m128i e = vZero, vF = vZero, vMaxColumn = vZero; /* Initialize F value to 0.
-							   Any errors to vH values will be corrected in the Lazy_F loop.
-							 */
-		//max16(maxColumn[i], vMaxColumn);
-		//fprintf(stderr, "middle[%d]: %d\n", i, maxColumn[i]);
+    /* outer loop to process the reference sequence */
+    if (ref_dir == 1) {
+        begin = refLen - 1;
+        end = -1;
+        step = -1;
+    }
+    for (i = begin; LIKELY(i != end); i += step) {
+        int32_t cmp;
+        __m128i e = vZero, vF = vZero, vMaxColumn = vZero; /* Initialize F value to 0.
+                               Any errors to vH values will be corrected in the Lazy_F loop.
+                             */
+        //max16(maxColumn[i], vMaxColumn);
+        //fprintf(stderr, "middle[%d]: %d\n", i, maxColumn[i]);
 
-		//__m128i vH = pvHStore[segLen - 1];
+        //__m128i vH = pvHStore[segLen - 1];
         __m128i vH = _mm_load_si128 (pvHStore + (segLen - 1));
-		vH = _mm_slli_si128 (vH, 1); /* Shift the 128-bit value in vH left by 1 byte. */
-		__m128i* vP = vProfile + ref[i] * segLen; /* Right part of the vProfile */
+        vH = _mm_slli_si128 (vH, 1); /* Shift the 128-bit value in vH left by 1 byte. */
+        __m128i* vP = vProfile + ref[i] * segLen; /* Right part of the vProfile */
 
-		/* Swap the 2 H buffers. */
-		__m128i* pv = pvHLoad;
-		pvHLoad = pvHStore;
-		pvHStore = pv;
+        /* Swap the 2 H buffers. */
+        __m128i* pv = pvHLoad;
+        pvHLoad = pvHStore;
+        pvHStore = pv;
 
-		/* inner loop to process the query sequence */
-		for (j = 0; LIKELY(j < segLen); ++j) {
+        /* inner loop to process the query sequence */
+        for (j = 0; LIKELY(j < segLen); ++j) {
 
-			vH = _mm_adds_epu8(vH, _mm_load_si128(vP + j));
-			vH = _mm_subs_epu8(vH, vBias); /* vH will be always > 0 */
-	//	max16(maxColumn[i], vH);
-	//	fprintf(stderr, "H[%d]: %d\n", i, maxColumn[i]);
+            vH = _mm_adds_epu8(vH, _mm_load_si128(vP + j));
+            vH = _mm_subs_epu8(vH, vBias); /* vH will be always > 0 */
+    //    max16(maxColumn[i], vH);
+    //    fprintf(stderr, "H[%d]: %d\n", i, maxColumn[i]);
             /*
             int8_t* t;
             int32_t ti;
@@ -685,13 +685,13 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
             fprintf(stdout, "\n");
             */
 
-			/* Get max from vH, vE and vF. */
-			e = _mm_load_si128(pvE + j);
-			//_mm_store_si128(vE + j, e);
+            /* Get max from vH, vE and vF. */
+            e = _mm_load_si128(pvE + j);
+            //_mm_store_si128(vE + j, e);
 
-			vH = _mm_max_epu8(vH, e);
-			vH = _mm_max_epu8(vH, vF);
-			vMaxColumn = _mm_max_epu8(vMaxColumn, vH);
+            vH = _mm_max_epu8(vH, e);
+            vH = _mm_max_epu8(vH, vF);
+            vMaxColumn = _mm_max_epu8(vMaxColumn, vH);
 
             // max16(maxColumn[i], vMaxColumn);
             //fprintf(stdout, "middle[%d]: %d\n", i, maxColumn[i]);
@@ -699,31 +699,31 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
             //for (t = (int8_t*)&vMaxColumn, ti = 0; ti < 16; ++ti) fprintf(stdout, "%d\t", *t++);
             //fprintf(stdout, "\n");
 
-			/* Save vH values. */
-			_mm_store_si128(pvHStore + j, vH);
-			
-			/* Save the vE and vF values they derived from */
-			_mm_store_si128(pvEStore + j, e);
-			_mm_store_si128(pvFStore + j, vF);
+            /* Save vH values. */
+            _mm_store_si128(pvHStore + j, vH);
+            
+            /* Save the vE and vF values they derived from */
+            _mm_store_si128(pvEStore + j, e);
+            _mm_store_si128(pvFStore + j, vF);
 
-			/* Update vE value. */
-			vH = _mm_subs_epu8(vH, vGapO); /* saturation arithmetic, result >= 0 */
-			e = _mm_subs_epu8(e, vGapE);
-			e = _mm_max_epu8(e, vH);
+            /* Update vE value. */
+            vH = _mm_subs_epu8(vH, vGapO); /* saturation arithmetic, result >= 0 */
+            e = _mm_subs_epu8(e, vGapE);
+            e = _mm_max_epu8(e, vH);
 
-			/* Update vF value. */
-			vF = _mm_subs_epu8(vF, vGapE);
-			vF = _mm_max_epu8(vF, vH);
+            /* Update vF value. */
+            vF = _mm_subs_epu8(vF, vGapE);
+            vF = _mm_max_epu8(vF, vH);
 
             /* Save E */
-			_mm_store_si128(pvE + j, e);
+            _mm_store_si128(pvE + j, e);
 
-			/* Load the next vH. */
-			vH = _mm_load_si128(pvHLoad + j);
-		}
+            /* Load the next vH. */
+            vH = _mm_load_si128(pvHLoad + j);
+        }
 
 
-		/* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
+        /* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
         /* reset pointers to the start of the saved data */
         j = 0;
         vH = _mm_load_si128 (pvHStore + j);
@@ -734,14 +734,14 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
         vF = _mm_slli_si128 (vF, 1);
 
         vTemp = _mm_subs_epu8 (vH, vGapO);
-		vTemp = _mm_subs_epu8 (vF, vTemp);
-		vTemp = _mm_cmpeq_epi8 (vTemp, vZero);
-		cmp  = _mm_movemask_epi8 (vTemp);
+        vTemp = _mm_subs_epu8 (vF, vTemp);
+        vTemp = _mm_cmpeq_epi8 (vTemp, vZero);
+        cmp  = _mm_movemask_epi8 (vTemp);
         while (cmp != 0xffff)
         {
             // Update this stripe of the H matrix
             vH = _mm_max_epu8 (vH, vF);
-			vMaxColumn = _mm_max_epu8(vMaxColumn, vH);
+            vMaxColumn = _mm_max_epu8(vMaxColumn, vH);
             _mm_store_si128 (pvHStore + j, vH);
 
             // Save the stripe of the F matrix
@@ -767,25 +767,25 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
             cmp  = _mm_movemask_epi8 (vTemp);
         }
 
-		vMaxScore = _mm_max_epu8(vMaxScore, vMaxColumn);
-		vTemp = _mm_cmpeq_epi8(vMaxMark, vMaxScore);
-		cmp = _mm_movemask_epi8(vTemp);
-		if (cmp != 0xffff) {
-			uint8_t temp;
-			vMaxMark = vMaxScore;
-			m128i_max16(temp, vMaxScore);
-			vMaxScore = vMaxMark;
+        vMaxScore = _mm_max_epu8(vMaxScore, vMaxColumn);
+        vTemp = _mm_cmpeq_epi8(vMaxMark, vMaxScore);
+        cmp = _mm_movemask_epi8(vTemp);
+        if (cmp != 0xffff) {
+            uint8_t temp;
+            vMaxMark = vMaxScore;
+            m128i_max16(temp, vMaxScore);
+            vMaxScore = vMaxMark;
 
-			if (LIKELY(temp > max)) {
-				max = temp;
-				if (max + bias >= 255) break;	//overflow
-				end_ref = i;
+            if (LIKELY(temp > max)) {
+                max = temp;
+                if (max + bias >= 255) break;    //overflow
+                end_ref = i;
 
-				/* Store the column with the highest alignment score in order to trace the alignment ending position on read. */
-				for (j = 0; LIKELY(j < segLen); ++j) pvHmax[j] = pvHStore[j];
+                /* Store the column with the highest alignment score in order to trace the alignment ending position on read. */
+                for (j = 0; LIKELY(j < segLen); ++j) pvHmax[j] = pvHStore[j];
 
-			}
-		}
+            }
+        }
 
         // save the current column for traceback
         // Need to unswizzle all the stripes
@@ -831,46 +831,46 @@ gssw_alignment_end* gssw_sw_sse2_byte (const int8_t* ref,
         }
 
 
-		/* Record the max score of current column. */
-		//max16(maxColumn[i], vMaxColumn);
-		//fprintf(stderr, "maxColumn[%d]: %d\n", i, maxColumn[i]);
-		//if (maxColumn[i] == terminate) break;
+        /* Record the max score of current column. */
+        //max16(maxColumn[i], vMaxColumn);
+        //fprintf(stderr, "maxColumn[%d]: %d\n", i, maxColumn[i]);
+        //if (maxColumn[i] == terminate) break;
 
-	}
+    }
         
     //fprintf(stderr, "%p %p %p %p %p %p\n", *pmH, mH, pvHmax, pvE, pvHLoad, pvHStore);
     // save the last vH
     memcpy(alignment->seed.pvE,      pvE,      segLen*sizeof(__m128i));
     memcpy(alignment->seed.pvHStore, pvHStore, segLen*sizeof(__m128i));
 
-	/* Trace the alignment ending position on read. */
-	uint8_t *t = (uint8_t*)pvHmax;
-	int32_t column_len = segLen * 16;
-	for (i = 0; LIKELY(i < column_len); ++i, ++t) {
-		int32_t temp;
-		if (*t == max) {
-			temp = i / 16 + i % 16 * segLen;
-			if (temp < end_read) end_read = temp;
-		}
-	}
+    /* Trace the alignment ending position on read. */
+    uint8_t *t = (uint8_t*)pvHmax;
+    int32_t column_len = segLen * 16;
+    for (i = 0; LIKELY(i < column_len); ++i, ++t) {
+        int32_t temp;
+        if (*t == max) {
+            temp = i / 16 + i % 16 * segLen;
+            if (temp < end_read) end_read = temp;
+        }
+    }
 
     //fprintf(stderr, "%p %p %p %p %p %p\n", *pmH, mH, pvHmax, pvE, pvHLoad, pvHStore);
 
-	free(pvE);
-	free(pvHmax);
-	free(pvHLoad);
+    free(pvE);
+    free(pvHmax);
+    free(pvHLoad);
     free(pvHStore);
     free(pvEStore);
     free(pvFStore);
 
-	/* Find the most possible 2nd best alignment. */
-	gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
-	bests[0].score = max + bias >= 255 ? 255 : max;
-	bests[0].ref = end_ref;
-	bests[0].read = end_read;
+    /* Find the most possible 2nd best alignment. */
+    gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
+    bests[0].score = max + bias >= 255 ? 255 : max;
+    bests[0].ref = end_ref;
+    bests[0].read = end_read;
 
 
-	return bests;
+    return bests;
 }
 
 __m128i* gssw_qP_word (const int8_t* read_num,
@@ -880,14 +880,14 @@ __m128i* gssw_qP_word (const int8_t* read_num,
                        int8_t start_full_length_bonus,
                        int8_t end_full_length_bonus) {
 
-	int32_t segLen = (readLen + 7) / 8;
-	__m128i* vProfile = (__m128i*)malloc(n * segLen * sizeof(__m128i));
-	int16_t* t = (int16_t*)vProfile;
-	int32_t nt, i, j;
-	int32_t segNum;
+    int32_t segLen = (readLen + 7) / 8;
+    __m128i* vProfile = (__m128i*)malloc(n * segLen * sizeof(__m128i));
+    int16_t* t = (int16_t*)vProfile;
+    int32_t nt, i, j;
+    int32_t segNum;
 
-	/* Generate query profile rearrange query sequence & calculate the weight of match/mismatch */
-	for (nt = 0; LIKELY(nt < n); nt ++) {
+    /* Generate query profile rearrange query sequence & calculate the weight of match/mismatch */
+    for (nt = 0; LIKELY(nt < n); nt ++) {
         // special logic for first vector to add bonus for full length pinned alignment
         if (segLen > 0) {
             j = 0;
@@ -905,16 +905,16 @@ __m128i* gssw_qP_word (const int8_t* read_num,
             }
         }
         
-		for (i = 1; i < segLen; i ++) {
-			j = i;
-			for (segNum = 0; LIKELY(segNum < 8) ; segNum ++) {
+        for (i = 1; i < segLen; i ++) {
+            j = i;
+            for (segNum = 0; LIKELY(segNum < 8) ; segNum ++) {
                 *t = j>= readLen ? 0 : mat[nt * n + read_num[j]] + (j == readLen - 1 ? end_full_length_bonus : 0);
                 t++;
-				j += segLen;
-			}
+                j += segLen;
+            }
         }
-	}
-	return vProfile;
+    }
+    return vProfile;
 }
 
 __m128i* gssw_adj_qP_word (const int8_t* read_num,
@@ -1105,7 +1105,7 @@ int16_t max_word(int16_t a, int16_t b) {
  * Used for computing known good alingments, for testing.
  */
 gssw_alignment_end* gssw_sw_software_word (const int8_t* ref,
-                                           int8_t ref_dir,	// 0: forward ref; 1: reverse ref
+                                           int8_t ref_dir,    // 0: forward ref; 1: reverse ref
                                            int32_t refLen,
                                            int32_t readLen,
                                            const uint8_t weight_gapO, /* will be used as - */
@@ -1118,9 +1118,9 @@ gssw_alignment_end* gssw_sw_software_word (const int8_t* ref,
                                            
     
                                        
-    int16_t max = 0;		                     /* the max alignment score */
-	int32_t end_read = readLen - 1;
-	int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
+    int16_t max = 0;                             /* the max alignment score */
+    int32_t end_read = readLen - 1;
+    int32_t end_ref = -1; /* 0_based best alignment ending point; Initialized as isn't aligned -1. */
 
     // We need to make sure out matrices are sized to the nearest 8, so pad the read length.
     int32_t padded_read_length = ((readLen + 7) / 8) * 8;
@@ -1187,51 +1187,51 @@ gssw_alignment_end* gssw_sw_software_word (const int8_t* ref,
     
     int32_t begin = 0, end = refLen, step = 1;
 
-	/* outer loop to process the reference sequence */
-	if (ref_dir == 1) {
-		begin = refLen - 1;
-		end = -1;
-		step = -1;
-	}
-	int32_t i;
-	for (i = begin; LIKELY(i != end); i += step) {
-	    // For each column i in the DP matrices (running in the appropriate direction)
-	    
-	    // We don't need the previous F column.
-	    // But we do need to push the current H and E columns to the previous ones.
-	    // We use a double buffering settup so we don't need to malloc and free and copy stuff.
-	    // By working with a previous and next column, we don't need to do anything fancy to support the flipable ref_dir.
-	    pv = pvHLoad;
-	    pvHLoad = pvHStore;
-	    pvHStore = pv;
-	    pv = pvELoad;
-	    pvELoad = pvEStore;
-	    pvEStore = pv;
-	    
-	    int32_t j;
-	    for (j = 0; j < readLen; j++) {
-	        // For each row j in the DP matrices (running top to bottom)
-	        
-	        // Set the gap-in-read matrix (E) based on previous E and previous H
-	        int16_t readGapOpenScore = subs_word(pvHLoad[j], weight_gapO);
-	        int16_t readGapExtendScore = subs_word(pvELoad[j], weight_gapE);
-	        pvEStore[j] = max_word(readGapOpenScore, readGapExtendScore);
-	        // Nothing negative is allowed in score matrices
-	        pvEStore[j] = max_word(pvEStore[j], 0);
-	        
-	        int16_t refGapOpenScore = 0;
-	        int16_t refGapExtendScore = 0;
-	        if (j == 0) {
-	            // We can only end in a gap in the reference on the first read character with negative score.
-	            pvFStore[j] = subs_word(0, weight_gapO);
-	        } else {
-	            // Set the gap-in-ref matrix (F) based on previous slot in current F and in current H
-	            refGapOpenScore = subs_word(pvHStore[j-1], weight_gapO);
-	            refGapExtendScore = subs_word(pvFStore[j-1], weight_gapE);
-	            pvFStore[j] = max_word(refGapOpenScore, refGapExtendScore);
-	        }
-	        // Nothing negative is allowed in score matrices
-	        pvFStore[j] = max_word(pvFStore[j], 0);
+    /* outer loop to process the reference sequence */
+    if (ref_dir == 1) {
+        begin = refLen - 1;
+        end = -1;
+        step = -1;
+    }
+    int32_t i;
+    for (i = begin; LIKELY(i != end); i += step) {
+        // For each column i in the DP matrices (running in the appropriate direction)
+        
+        // We don't need the previous F column.
+        // But we do need to push the current H and E columns to the previous ones.
+        // We use a double buffering settup so we don't need to malloc and free and copy stuff.
+        // By working with a previous and next column, we don't need to do anything fancy to support the flipable ref_dir.
+        pv = pvHLoad;
+        pvHLoad = pvHStore;
+        pvHStore = pv;
+        pv = pvELoad;
+        pvELoad = pvEStore;
+        pvEStore = pv;
+        
+        int32_t j;
+        for (j = 0; j < readLen; j++) {
+            // For each row j in the DP matrices (running top to bottom)
+            
+            // Set the gap-in-read matrix (E) based on previous E and previous H
+            int16_t readGapOpenScore = subs_word(pvHLoad[j], weight_gapO);
+            int16_t readGapExtendScore = subs_word(pvELoad[j], weight_gapE);
+            pvEStore[j] = max_word(readGapOpenScore, readGapExtendScore);
+            // Nothing negative is allowed in score matrices
+            pvEStore[j] = max_word(pvEStore[j], 0);
+            
+            int16_t refGapOpenScore = 0;
+            int16_t refGapExtendScore = 0;
+            if (j == 0) {
+                // We can only end in a gap in the reference on the first read character with negative score.
+                pvFStore[j] = subs_word(0, weight_gapO);
+            } else {
+                // Set the gap-in-ref matrix (F) based on previous slot in current F and in current H
+                refGapOpenScore = subs_word(pvHStore[j-1], weight_gapO);
+                refGapExtendScore = subs_word(pvFStore[j-1], weight_gapE);
+                pvFStore[j] = max_word(refGapOpenScore, refGapExtendScore);
+            }
+            // Nothing negative is allowed in score matrices
+            pvFStore[j] = max_word(pvFStore[j], 0);
 
             // What score are we adding to with a match?
             // If there's nowhere to come from it's 0.
@@ -1247,64 +1247,64 @@ gssw_alignment_end* gssw_sw_software_word (const int8_t* ref,
             int16_t matchScore = adds_word(matchFrom, profileScore);
             // No bias
             // We're working 16 bit with signed profile words)
-	        
-	        // Set the normal (H) matrix based on current E, current F, and match/mismatch score
-	        pvHStore[j] = max_word(max_word(pvEStore[j], pvFStore[j]), matchScore);
-	        // Nothing negative is allowed in score matrices
-	        pvHStore[j] = max_word(pvHStore[j], 0);
+            
+            // Set the normal (H) matrix based on current E, current F, and match/mismatch score
+            pvHStore[j] = max_word(max_word(pvEStore[j], pvFStore[j]), matchScore);
+            // Nothing negative is allowed in score matrices
+            pvHStore[j] = max_word(pvHStore[j], 0);
 
 #ifdef DEBUG_SOFTWARE_FILL
-	        // Dump the matrix as we fill it.
-	        fprintf(stderr, "(%d, %d): Read O:%hd E:%hd Ref O:%hd E:%hd Match:%hd+%hd=%hd\n",
-	            i, j,
-	            readGapOpenScore, readGapExtendScore,
-	            refGapOpenScore, refGapExtendScore,
-	            matchFrom, profileScore, matchScore);
+            // Dump the matrix as we fill it.
+            fprintf(stderr, "(%d, %d): Read O:%hd E:%hd Ref O:%hd E:%hd Match:%hd+%hd=%hd\n",
+                i, j,
+                readGapOpenScore, readGapExtendScore,
+                refGapOpenScore, refGapExtendScore,
+                matchFrom, profileScore, matchScore);
 #endif
-	    
-	        // Set the running max
-	        if (pvHStore[j] > max) {
-	            max = pvHStore[j];
-	            end_ref = i;
-	            end_read = j;
-	        }
-	        
-	        // Copy from columns to matrices
-	        mH[i * readLen + j] = pvHStore[j];
-	        mE[i * readLen + j] = pvEStore[j];
-	        mF[i * readLen + j] = pvFStore[j];
-	    }
-	}
-	
-	// Reswizzle seeds
-	swizzle_word(pvEStore, padded_read_length);
-	swizzle_word(pvHStore, padded_read_length);
-	
-	// Save seeds.
+        
+            // Set the running max
+            if (pvHStore[j] > max) {
+                max = pvHStore[j];
+                end_ref = i;
+                end_read = j;
+            }
+            
+            // Copy from columns to matrices
+            mH[i * readLen + j] = pvHStore[j];
+            mE[i * readLen + j] = pvEStore[j];
+            mF[i * readLen + j] = pvFStore[j];
+        }
+    }
+    
+    // Reswizzle seeds
+    swizzle_word(pvEStore, padded_read_length);
+    swizzle_word(pvHStore, padded_read_length);
+    
+    // Save seeds.
     memcpy(alignment->seed.pvE,      pvEStore, padded_read_length * sizeof(int16_t));
     memcpy(alignment->seed.pvHStore, pvHStore, padded_read_length * sizeof(int16_t));
 
     // Clean up all the buffers
-	free(pvHLoad);
+    free(pvHLoad);
     free(pvHStore);
     free(pvELoad);
     free(pvEStore);
     // No pvFLoad.
     free(pvFStore);
 
-	/* Find the most possible 2nd best alignment. */
-	// TODO: this only does the best alignment???
-	gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
-	bests[0].score = max;
-	bests[0].ref = end_ref;
-	bests[0].read = end_read;
+    /* Find the most possible 2nd best alignment. */
+    // TODO: this only does the best alignment???
+    gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
+    bests[0].score = max;
+    bests[0].ref = end_ref;
+    bests[0].read = end_read;
 
-	return bests;
+    return bests;
 }
 
 
 gssw_alignment_end* gssw_sw_sse2_word (const int8_t* ref,
-                                       int8_t ref_dir,	// 0: forward ref; 1: reverse ref
+                                       int8_t ref_dir,    // 0: forward ref; 1: reverse ref
                                        int32_t refLen,
                                        int32_t readLen,
                                        const uint8_t weight_gapO, /* will be used as - */
@@ -1316,13 +1316,13 @@ gssw_alignment_end* gssw_sw_sse2_word (const int8_t* ref,
                                        const gssw_seed* seed) {     /* to seed the alignment */
     
 
-	uint16_t max = 0;		                     /* the max alignment score */
-	int32_t end_read = readLen - 1;
-	int32_t end_ref = 0; /* 1_based best alignment ending point; Initialized as isn't aligned - 0. */
-	int32_t segLen = (readLen + 7) / 8; /* number of segment */
+    uint16_t max = 0;                             /* the max alignment score */
+    int32_t end_read = readLen - 1;
+    int32_t end_ref = 0; /* 1_based best alignment ending point; Initialized as isn't aligned - 0. */
+    int32_t segLen = (readLen + 7) / 8; /* number of segment */
 
     /* Initialize buffers used in alignment */
-	__m128i* pvHStore;
+    __m128i* pvHStore;
     __m128i* pvHLoad;
     __m128i* pvHmax;
     __m128i* pvE;
@@ -1376,116 +1376,116 @@ gssw_alignment_end* gssw_sw_sse2_word (const int8_t* ref,
     /* Record that we have done a word-order alignment */
     alignment->is_byte = 0;
 
-	/* Define 16 byte 0 vector. */
-	__m128i vZero = _mm_set1_epi32(0);
+    /* Define 16 byte 0 vector. */
+    __m128i vZero = _mm_set1_epi32(0);
 
     /* Used for iteration */
-	int32_t i, j, k;
+    int32_t i, j, k;
 
-	/* 16 byte insertion begin vector */
-	__m128i vGapO = _mm_set1_epi16(weight_gapO);
+    /* 16 byte insertion begin vector */
+    __m128i vGapO = _mm_set1_epi16(weight_gapO);
 
-	/* 16 byte insertion extension vector */
-	__m128i vGapE = _mm_set1_epi16(weight_gapE);
+    /* 16 byte insertion extension vector */
+    __m128i vGapE = _mm_set1_epi16(weight_gapE);
 
-	/* 16 byte bias vector */
-	__m128i vMaxScore = vZero; /* Trace the highest score of the whole SW matrix. */
-	__m128i vMaxMark = vZero; /* Trace the highest score till the previous column. */
-	__m128i vTemp;
-	int32_t begin = 0, end = refLen, step = 1;
+    /* 16 byte bias vector */
+    __m128i vMaxScore = vZero; /* Trace the highest score of the whole SW matrix. */
+    __m128i vMaxMark = vZero; /* Trace the highest score till the previous column. */
+    __m128i vTemp;
+    int32_t begin = 0, end = refLen, step = 1;
 
-	/* outer loop to process the reference sequence */
-	if (ref_dir == 1) {
-		begin = refLen - 1;
-		end = -1;
-		step = -1;
-	}
-	for (i = begin; LIKELY(i != end); i += step) {
-		int32_t cmp;
-		__m128i e = vZero, vF = vZero; /* Initialize F value to 0.
-							   Any errors to vH values will be corrected in the Lazy_F loop.
-							 */
-		__m128i vH = pvHStore[segLen - 1];
-		vH = _mm_slli_si128 (vH, 2); /* Shift the 128-bit value in vH left by 2 byte. */
+    /* outer loop to process the reference sequence */
+    if (ref_dir == 1) {
+        begin = refLen - 1;
+        end = -1;
+        step = -1;
+    }
+    for (i = begin; LIKELY(i != end); i += step) {
+        int32_t cmp;
+        __m128i e = vZero, vF = vZero; /* Initialize F value to 0.
+                               Any errors to vH values will be corrected in the Lazy_F loop.
+                             */
+        __m128i vH = pvHStore[segLen - 1];
+        vH = _mm_slli_si128 (vH, 2); /* Shift the 128-bit value in vH left by 2 byte. */
 
-		/* Swap the 2 H buffers. */
-		__m128i* pv = pvHLoad;
+        /* Swap the 2 H buffers. */
+        __m128i* pv = pvHLoad;
 
-		__m128i vMaxColumn = vZero; /* vMaxColumn is used to record the max values of column i. */
+        __m128i vMaxColumn = vZero; /* vMaxColumn is used to record the max values of column i. */
 
-		__m128i* vP = vProfile + ref[i] * segLen; /* Right part of the vProfile */
-		pvHLoad = pvHStore;
-		pvHStore = pv;
+        __m128i* vP = vProfile + ref[i] * segLen; /* Right part of the vProfile */
+        pvHLoad = pvHStore;
+        pvHStore = pv;
 
-		/* inner loop to process the query sequence */
-		for (j = 0; LIKELY(j < segLen); j ++) {
-			vH = _mm_adds_epi16(vH, _mm_load_si128(vP + j));
+        /* inner loop to process the query sequence */
+        for (j = 0; LIKELY(j < segLen); j ++) {
+            vH = _mm_adds_epi16(vH, _mm_load_si128(vP + j));
 
-			/* Get max from vH, vE and vF. */
-			e = _mm_load_si128(pvE + j);
-			vH = _mm_max_epi16(vH, e);
-			vH = _mm_max_epi16(vH, vF);
-			vMaxColumn = _mm_max_epi16(vMaxColumn, vH);
+            /* Get max from vH, vE and vF. */
+            e = _mm_load_si128(pvE + j);
+            vH = _mm_max_epi16(vH, e);
+            vH = _mm_max_epi16(vH, vF);
+            vMaxColumn = _mm_max_epi16(vMaxColumn, vH);
 
-			/* Save vH values. */
-			_mm_store_si128(pvHStore + j, vH);
-			
-			/* Save the vE and vF values they derived from */
-			_mm_store_si128(pvEStore + j, e);
-			_mm_store_si128(pvFStore + j, vF);
+            /* Save vH values. */
+            _mm_store_si128(pvHStore + j, vH);
+            
+            /* Save the vE and vF values they derived from */
+            _mm_store_si128(pvEStore + j, e);
+            _mm_store_si128(pvFStore + j, vF);
 
-			/* Update vE value. */
-			vH = _mm_subs_epu16(vH, vGapO); /* saturation arithmetic, result >= 0 */
-			e = _mm_subs_epu16(e, vGapE);
-			e = _mm_max_epi16(e, vH);
-			_mm_store_si128(pvE + j, e);
+            /* Update vE value. */
+            vH = _mm_subs_epu16(vH, vGapO); /* saturation arithmetic, result >= 0 */
+            e = _mm_subs_epu16(e, vGapE);
+            e = _mm_max_epi16(e, vH);
+            _mm_store_si128(pvE + j, e);
 
-			/* Update vF value. */
-			vF = _mm_subs_epu16(vF, vGapE);
-			vF = _mm_max_epi16(vF, vH);
+            /* Update vF value. */
+            vF = _mm_subs_epu16(vF, vGapE);
+            vF = _mm_max_epi16(vF, vH);
 
-			/* Load the next vH. */
-			vH = _mm_load_si128(pvHLoad + j);
-		}
+            /* Load the next vH. */
+            vH = _mm_load_si128(pvHLoad + j);
+        }
 
-		/* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
-		for (k = 0; LIKELY(k < 8); ++k) {
-			vF = _mm_slli_si128 (vF, 2);
-			for (j = 0; LIKELY(j < segLen); ++j) {
-			    // Update this stripe of the H matrix
-				vH = _mm_load_si128(pvHStore + j);
-				vH = _mm_max_epi16(vH, vF);
-				_mm_store_si128(pvHStore + j, vH);
-				
-				// Save the stripe of the F matrix
+        /* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
+        for (k = 0; LIKELY(k < 8); ++k) {
+            vF = _mm_slli_si128 (vF, 2);
+            for (j = 0; LIKELY(j < segLen); ++j) {
+                // Update this stripe of the H matrix
+                vH = _mm_load_si128(pvHStore + j);
+                vH = _mm_max_epi16(vH, vF);
+                _mm_store_si128(pvHStore + j, vH);
+                
+                // Save the stripe of the F matrix
                 // Only add in better F scores. Sometimes during this loop we'll
                 // recompute worse ones.
                 vTemp = _mm_load_si128 (pvFStore + j);
                 vTemp = _mm_max_epi16 (vTemp, vF);
                 _mm_store_si128(pvFStore + j, vTemp);
-				
-				vH = _mm_subs_epu16(vH, vGapO);
-				vF = _mm_subs_epu16(vF, vGapE);
-				if (UNLIKELY(! _mm_movemask_epi8(_mm_cmpgt_epi16(vF, vH)))) goto end;
-			}
-		}
+                
+                vH = _mm_subs_epu16(vH, vGapO);
+                vF = _mm_subs_epu16(vF, vGapE);
+                if (UNLIKELY(! _mm_movemask_epi8(_mm_cmpgt_epi16(vF, vH)))) goto end;
+            }
+        }
 
 end:
-		vMaxScore = _mm_max_epi16(vMaxScore, vMaxColumn);
-		vTemp = _mm_cmpeq_epi16(vMaxMark, vMaxScore);
-		cmp = _mm_movemask_epi8(vTemp);
-		if (cmp != 0xffff) {
-			uint16_t temp;
-			vMaxMark = vMaxScore;
-			m128i_max8(temp, vMaxScore);
-			vMaxScore = vMaxMark;
+        vMaxScore = _mm_max_epi16(vMaxScore, vMaxColumn);
+        vTemp = _mm_cmpeq_epi16(vMaxMark, vMaxScore);
+        cmp = _mm_movemask_epi8(vTemp);
+        if (cmp != 0xffff) {
+            uint16_t temp;
+            vMaxMark = vMaxScore;
+            m128i_max8(temp, vMaxScore);
+            vMaxScore = vMaxMark;
 
-			if (LIKELY(temp > max)) {
-				max = temp;
-				end_ref = i;
-				for (j = 0; LIKELY(j < segLen); ++j) pvHmax[j] = pvHStore[j];
-			}
-		}
+            if (LIKELY(temp > max)) {
+                max = temp;
+                end_ref = i;
+                for (j = 0; LIKELY(j < segLen); ++j) pvHmax[j] = pvHStore[j];
+            }
+        }
 
         /* save current column */
         
@@ -1528,54 +1528,54 @@ end:
         }
         
 
-		/* Record the max score of current column. */
-		//max8(maxColumn[i], vMaxColumn);
-		//if (maxColumn[i] == terminate) break;
+        /* Record the max score of current column. */
+        //max8(maxColumn[i], vMaxColumn);
+        //if (maxColumn[i] == terminate) break;
 
-	}
+    }
 
     memcpy(alignment->seed.pvE,      pvE,      segLen*sizeof(__m128i));
     memcpy(alignment->seed.pvHStore, pvHStore, segLen*sizeof(__m128i));
 
 
-	/* Trace the alignment ending position on read. */
-	uint16_t *t = (uint16_t*)pvHmax;
-	int32_t column_len = segLen * 8;
-	for (i = 0; LIKELY(i < column_len); ++i, ++t) {
-		int32_t temp;
-		if (*t == max) {
-			temp = i / 8 + i % 8 * segLen;
-			if (temp < end_read) end_read = temp;
-		}
-	}
+    /* Trace the alignment ending position on read. */
+    uint16_t *t = (uint16_t*)pvHmax;
+    int32_t column_len = segLen * 8;
+    for (i = 0; LIKELY(i < column_len); ++i, ++t) {
+        int32_t temp;
+        if (*t == max) {
+            temp = i / 8 + i % 8 * segLen;
+            if (temp < end_read) end_read = temp;
+        }
+    }
 
-	free(pvE);
-	free(pvHmax);
-	free(pvHLoad);
+    free(pvE);
+    free(pvHmax);
+    free(pvHLoad);
     free(pvHStore);
     free(pvEStore);
     free(pvFStore);
 
-	/* Find the most possible 2nd best alignment. */
-	gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
-	bests[0].score = max;
-	bests[0].ref = end_ref;
-	bests[0].read = end_read;
+    /* Find the most possible 2nd best alignment. */
+    gssw_alignment_end* bests = (gssw_alignment_end*) calloc(2, sizeof(gssw_alignment_end));
+    bests[0].score = max;
+    bests[0].ref = end_ref;
+    bests[0].read = end_read;
 
-	return bests;
+    return bests;
 }
 
-int8_t* gssw_seq_reverse(const int8_t* seq, int32_t end)	/* end is 0-based alignment ending position */
+int8_t* gssw_seq_reverse(const int8_t* seq, int32_t end)    /* end is 0-based alignment ending position */
 {
-	int8_t* reverse = (int8_t*)calloc(end + 1, sizeof(int8_t));
-	int32_t start = 0;
-	while (LIKELY(start <= end)) {
-		reverse[start] = seq[end];
-		reverse[end] = seq[start];
-		++ start;
-		-- end;
-	}
-	return reverse;
+    int8_t* reverse = (int8_t*)calloc(end + 1, sizeof(int8_t));
+    int32_t start = 0;
+    while (LIKELY(start <= end)) {
+        reverse[start] = seq[end];
+        reverse[end] = seq[start];
+        ++ start;
+        -- end;
+    }
+    return reverse;
 }
 
 int8_t gssw_max_qual(const int8_t* qual, const int32_t len) {
@@ -1591,28 +1591,28 @@ int8_t gssw_max_qual(const int8_t* qual, const int32_t len) {
 
 gssw_profile* gssw_init (const int8_t* read, const int32_t readLen, const int8_t* mat, const int32_t n,
                          int8_t start_full_length_bonus, int8_t end_full_length_bonus, const int8_t score_size) {
-	gssw_profile* p = (gssw_profile*)calloc(1, sizeof(struct gssw_profile));
-	p->profile_byte = 0;
-	p->profile_word = 0;
-	p->bias = 0;
+    gssw_profile* p = (gssw_profile*)calloc(1, sizeof(struct gssw_profile));
+    p->profile_byte = 0;
+    p->profile_word = 0;
+    p->bias = 0;
 
-	if (score_size == 0 || score_size == 2) {
-		/* Find the bias to use in the substitution matrix */
-		int32_t bias = 0, i;
-		for (i = 0; i < n*n; i++) if (mat[i] < bias) bias = mat[i];
-		bias = abs(bias);
+    if (score_size == 0 || score_size == 2) {
+        /* Find the bias to use in the substitution matrix */
+        int32_t bias = 0, i;
+        for (i = 0; i < n*n; i++) if (mat[i] < bias) bias = mat[i];
+        bias = abs(bias);
 
-		p->bias = bias;
-		p->profile_byte = gssw_qP_byte (read, mat, readLen, n, bias, start_full_length_bonus, end_full_length_bonus);
-	}
-	if (score_size == 1 || score_size == 2) p->profile_word = gssw_qP_word (read, mat, readLen, n,
+        p->bias = bias;
+        p->profile_byte = gssw_qP_byte (read, mat, readLen, n, bias, start_full_length_bonus, end_full_length_bonus);
+    }
+    if (score_size == 1 || score_size == 2) p->profile_word = gssw_qP_word (read, mat, readLen, n,
                                                                             start_full_length_bonus,
                                                                             end_full_length_bonus);
-	p->read = read;
-	p->mat = mat;
-	p->readLen = readLen;
-	p->n = n;
-	return p;
+    p->read = read;
+    p->mat = mat;
+    p->readLen = readLen;
+    p->n = n;
+    return p;
 }
 
 /* Initiailize a profile with quality adjusted scores. */
@@ -1646,9 +1646,9 @@ gssw_profile* gssw_qual_adj_init (const int8_t* read, const int8_t* qual, const 
 }
 
 void gssw_init_destroy (gssw_profile* p) {
-	free(p->profile_byte);
-	free(p->profile_word);
-	free(p);
+    free(p->profile_byte);
+    free(p->profile_word);
+    free(p);
 }
 
 gssw_align* gssw_fill (const gssw_profile* prof,
@@ -1659,33 +1659,33 @@ gssw_align* gssw_fill (const gssw_profile* prof,
                        const int32_t maskLen,
                        gssw_seed* seed) {
 
-	gssw_alignment_end* bests = 0;
-	int32_t readLen = prof->readLen;
+    gssw_alignment_end* bests = 0;
+    int32_t readLen = prof->readLen;
     gssw_align* alignment = gssw_align_create();
 
-	if (maskLen < 15) {
-		fprintf(stderr, "When maskLen < 15, the function ssw_align doesn't return 2nd best alignment information.\n");
-	}
+    if (maskLen < 15) {
+        fprintf(stderr, "When maskLen < 15, the function ssw_align doesn't return 2nd best alignment information.\n");
+    }
 
-	// Find the alignment scores and ending positions
-	if (prof->profile_byte) {
-	    // Do a byte-sized fill
-	    
-	    if (gssw_sse2_enabled) {
-	        // Use SSE2
-		    bests = gssw_sw_sse2_byte(ref, 0, refLen, readLen, weight_gapO, weight_gapE,
-		                              prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
+    // Find the alignment scores and ending positions
+    if (prof->profile_byte) {
+        // Do a byte-sized fill
+        
+        if (gssw_sse2_enabled) {
+            // Use SSE2
+            bests = gssw_sw_sse2_byte(ref, 0, refLen, readLen, weight_gapO, weight_gapE,
+                                      prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
         } else {
             // Use software
             bests = gssw_sw_software_byte(ref, 0, refLen, readLen, weight_gapO, weight_gapE,
-		                                  prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
+                                          prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
         }
 
-		if (prof->profile_word && bests[0].score == 255) {
-			free(bests);
+        if (prof->profile_word && bests[0].score == 255) {
+            free(bests);
             gssw_align_clear_matrix_and_seed(alignment);
             if (gssw_sse2_enabled) {
-	            // Use SSE2
+                // Use SSE2
                 bests = gssw_sw_sse2_word(ref, 0, refLen, readLen, weight_gapO, weight_gapE, prof->profile_byte, -1, maskLen,
                                           alignment, seed);
             } else {
@@ -1694,40 +1694,40 @@ gssw_align* gssw_fill (const gssw_profile* prof,
                                               alignment, seed);
             }
         } else if (bests[0].score == 255) {
-			fprintf(stderr, "Please set 2 to the score_size parameter of the function ssw_init, otherwise the alignment results will be incorrect.\n");
-			return 0;
-		}
-	} else if (prof->profile_word) {
-	    if (gssw_sse2_enabled) {
+            fprintf(stderr, "Please set 2 to the score_size parameter of the function ssw_init, otherwise the alignment results will be incorrect.\n");
+            return 0;
+        }
+    } else if (prof->profile_word) {
+        if (gssw_sse2_enabled) {
             // Use SSE2
-		    bests = gssw_sw_sse2_word(ref, 0, refLen, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen,
+            bests = gssw_sw_sse2_word(ref, 0, refLen, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen,
                                       alignment, seed);
         } else {
             // Use software
-		    bests = gssw_sw_software_word(ref, 0, refLen, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen,
+            bests = gssw_sw_software_word(ref, 0, refLen, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen,
                                           alignment, seed);
         }
     } else {
-		fprintf(stderr, "Please call the function ssw_init before ssw_align.\n");
-		return 0;
-	}
+        fprintf(stderr, "Please call the function ssw_init before ssw_align.\n");
+        return 0;
+    }
     
     
     
-	alignment->score1 = bests[0].score;
-	alignment->ref_end1 = bests[0].ref;
-	alignment->read_end1 = bests[0].read;
-	if (maskLen >= 15) {
-		alignment->score2 = bests[1].score;
-		alignment->ref_end2 = bests[1].ref;
-	} else {
-	    alignment->score2 = 0;
-		alignment->ref_end2 = -1;
-	}
-	free(bests);
+    alignment->score1 = bests[0].score;
+    alignment->ref_end1 = bests[0].ref;
+    alignment->read_end1 = bests[0].read;
+    if (maskLen >= 15) {
+        alignment->score2 = bests[1].score;
+        alignment->ref_end2 = bests[1].ref;
+    } else {
+        alignment->score2 = 0;
+        alignment->ref_end2 = -1;
+    }
+    free(bests);
     
 
-	return alignment;
+    return alignment;
 }
 
 gssw_align* gssw_align_create (void) {
@@ -1737,14 +1737,14 @@ gssw_align* gssw_align_create (void) {
     a->mH = NULL;
     a->mE = NULL;
     a->mF = NULL;
-	a->ref_begin1 = -1;
-	a->read_begin1 = -1;
+    a->ref_begin1 = -1;
+    a->read_begin1 = -1;
     return a;
 }
 
 void gssw_align_destroy (gssw_align* a) {
     gssw_align_clear_matrix_and_seed(a);
-	free(a);
+    free(a);
 }
 
 void gssw_align_clear_matrix_and_seed (gssw_align* a) {
@@ -2024,7 +2024,7 @@ gssw_cigar* gssw_alignment_trace_back_byte (gssw_node* node,
     }
     
     // Start a CIGAR to hold the traceback.
-	gssw_cigar* result = (gssw_cigar*)calloc(1, sizeof(gssw_cigar));
+    gssw_cigar* result = (gssw_cigar*)calloc(1, sizeof(gssw_cigar));
     result->length = 0;
 
     while (LIKELY(scoreHere > 0 && i >= 0 && j >= 0)) {
@@ -2755,7 +2755,7 @@ gssw_cigar* gssw_alignment_trace_back_word (gssw_node* node,
     }
     
     // Start a CIGAR to hold the traceback.
-	gssw_cigar* result = (gssw_cigar*)calloc(1, sizeof(gssw_cigar));
+    gssw_cigar* result = (gssw_cigar*)calloc(1, sizeof(gssw_cigar));
     result->length = 0;
 
     while (LIKELY(scoreHere > 0 && i >= 0 && j >= 0)) {
@@ -3448,19 +3448,19 @@ char* gssw_graph_mapping_to_string(gssw_graph_mapping* gm) {
 */
 
 void gssw_reverse_graph_cigar(gssw_graph_cigar* c) {
-	gssw_graph_cigar* reversed = (gssw_graph_cigar*)malloc(sizeof(gssw_graph_cigar));
+    gssw_graph_cigar* reversed = (gssw_graph_cigar*)malloc(sizeof(gssw_graph_cigar));
     reversed->length = c->length;
-	reversed->elements = (gssw_node_cigar*) malloc(c->length * sizeof(gssw_node_cigar));
+    reversed->elements = (gssw_node_cigar*) malloc(c->length * sizeof(gssw_node_cigar));
     gssw_node_cigar* c1 = c->elements;
     gssw_node_cigar* c2 = reversed->elements;
-	int32_t s = 0;
-	int32_t e = c->length - 1;
-	while (LIKELY(s <= e)) {
-		c2[s] = c1[e];
-		c2[e] = c1[s];
-		++ s;
-		-- e;
-	}
+    int32_t s = 0;
+    int32_t e = c->length - 1;
+    while (LIKELY(s <= e)) {
+        c2[s] = c1[e];
+        c2[e] = c1[s];
+        ++ s;
+        -- e;
+    }
     free(c->elements);
     c->elements = reversed->elements;
     free(reversed);
@@ -4674,19 +4674,19 @@ void gssw_cigar_push_front(gssw_cigar* c, char type, uint32_t length) {
 
 void gssw_reverse_cigar(gssw_cigar* c) {
     if (!c->length) return; // bail out
-	gssw_cigar* reversed = (gssw_cigar*)malloc(sizeof(gssw_cigar));
+    gssw_cigar* reversed = (gssw_cigar*)malloc(sizeof(gssw_cigar));
     reversed->length = c->length;
-	reversed->elements = (gssw_cigar_element*) malloc(c->length * sizeof(gssw_cigar_element));
+    reversed->elements = (gssw_cigar_element*) malloc(c->length * sizeof(gssw_cigar_element));
     gssw_cigar_element* c1 = c->elements;
     gssw_cigar_element* c2 = reversed->elements;
-	int32_t s = 0;
-	int32_t e = c->length - 1;
-	while (LIKELY(s <= e)) {
-		c2[s] = c1[e];
-		c2[e] = c1[s];
-		++ s;
-		-- e;
-	}
+    int32_t s = 0;
+    int32_t e = c->length - 1;
+    while (LIKELY(s <= e)) {
+        c2[s] = c1[e];
+        c2[e] = c1[s];
+        ++ s;
+        -- e;
+    }
     free(c->elements);
     c->elements = reversed->elements;
     free(reversed);
@@ -4851,7 +4851,7 @@ gssw_seed* gssw_create_seed_byte(int32_t readLen, gssw_node** prev, int32_t coun
         }
     }
     __m128i vZero = _mm_set1_epi32(0);
-	int32_t segLen = (readLen + 15) / 16;
+    int32_t segLen = (readLen + 15) / 16;
     gssw_seed* seed = (gssw_seed*)calloc(1, sizeof(gssw_seed));
     if (!(!posix_memalign((void**)&seed->pvE,      sizeof(__m128i), segLen*sizeof(__m128i)) &&
           !posix_memalign((void**)&seed->pvHStore, sizeof(__m128i), segLen*sizeof(__m128i)))) {
@@ -4886,7 +4886,7 @@ gssw_seed* gssw_create_seed_word(int32_t readLen, gssw_node** prev, int32_t coun
         }
     }
     __m128i vZero = _mm_set1_epi32(0);
-	int32_t segLen = (readLen + 7) / 8;
+    int32_t segLen = (readLen + 7) / 8;
     gssw_seed* seed = (gssw_seed*)calloc(1, sizeof(gssw_seed));
     if (!(!posix_memalign((void**)&seed->pvE,      sizeof(__m128i), segLen*sizeof(__m128i)) &&
           !posix_memalign((void**)&seed->pvHStore, sizeof(__m128i), segLen*sizeof(__m128i)))) {
@@ -5104,8 +5104,8 @@ gssw_node_fill (gssw_node* node,
                 const int32_t maskLen,
                 const gssw_seed* seed) {
 
-	gssw_alignment_end* bests = NULL;
-	int32_t readLen = prof->readLen;
+    gssw_alignment_end* bests = NULL;
+    int32_t readLen = prof->readLen;
 
     //alignment_end* best = (alignment_end*)calloc(1, sizeof(alignment_end));
     gssw_align* alignment = node->alignment;
@@ -5126,50 +5126,50 @@ gssw_node_fill (gssw_node* node,
     // to decrease code complexity, we assume the same stripe size for the entire graph
     // this is ensured by changing the stripe size for the entire graph in graph_fill if any node scores >= 255
 
-	// Find the alignment scores and ending positions
-	if (prof->profile_byte) {
-	    // Do a byte-sized fill
-	    
-	    if (gssw_sse2_enabled) {
-		    // Use SSE2
-		    bests = gssw_sw_sse2_byte((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
-	    } else {
-	        // Use pure software
-	        bests = gssw_sw_software_byte((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
-	    }
-		if (bests[0].score == 255) {
-			free(bests);
+    // Find the alignment scores and ending positions
+    if (prof->profile_byte) {
+        // Do a byte-sized fill
+        
+        if (gssw_sse2_enabled) {
+            // Use SSE2
+            bests = gssw_sw_sse2_byte((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
+        } else {
+            // Use pure software
+            bests = gssw_sw_software_byte((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_byte, -1, prof->bias, maskLen, alignment, seed);
+        }
+        if (bests[0].score == 255) {
+            free(bests);
             gssw_align_clear_matrix_and_seed(alignment);
             return 0; // re-run from external context
-		}
-	} else if (prof->profile_word) {
-	    if (gssw_sse2_enabled) {
-		    // Use SSE2
+        }
+    } else if (prof->profile_word) {
+        if (gssw_sse2_enabled) {
+            // Use SSE2
             bests = gssw_sw_sse2_word((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen, alignment, seed);
         } else {
             // Use software
             bests = gssw_sw_software_word((const int8_t*)node->num, 0, node->len, readLen, weight_gapO, weight_gapE, prof->profile_word, -1, maskLen, alignment, seed);
         }
     } else {
-		fprintf(stderr, "Please call the function ssw_init before ssw_align.\n");
-		return 0;
-	}
+        fprintf(stderr, "Please call the function ssw_init before ssw_align.\n");
+        return 0;
+    }
     
     //fprintf(stderr, "### best: score(%d), ref_end(%d), read_end(%d); 2nd best: score(%d), ref_end(%d), read_end(%d)\n", bests[0].score, bests[0].ref, bests[0].read, bests[1].score, bests[1].ref, bests[1].read);
     
-	alignment->score1 = bests[0].score;
-	alignment->ref_end1 = bests[0].ref;
-	alignment->read_end1 = bests[0].read;
-	if (maskLen >= 15) {
-		alignment->score2 = bests[1].score;
-		alignment->ref_end2 = bests[1].ref;
-	} else {
-	    alignment->score2 = 0;
-		alignment->ref_end2 = -1;
-	}
-	free(bests);
+    alignment->score1 = bests[0].score;
+    alignment->ref_end1 = bests[0].ref;
+    alignment->read_end1 = bests[0].read;
+    if (maskLen >= 15) {
+        alignment->score2 = bests[1].score;
+        alignment->ref_end2 = bests[1].ref;
+    } else {
+        alignment->score2 = 0;
+        alignment->ref_end2 = -1;
+    }
+    free(bests);
 
-	return node;
+    return node;
 
 }
 
@@ -5217,7 +5217,7 @@ int8_t* gssw_create_num(const char* seq,
                         const int8_t* nt_table) {
     int32_t m;
     int8_t* num = (int8_t*)malloc(len);
-	for (m = 0; m < len; ++m) num[m] = nt_table[(int)seq[m]];
+    for (m = 0; m < len; ++m) num[m] = nt_table[(int)seq[m]];
     return num;
 }
 
@@ -5234,35 +5234,35 @@ int8_t* gssw_create_qual_num(const char* qual,
 
 
 int8_t* gssw_create_score_matrix(int32_t match, int32_t mismatch) {
-	// initialize scoring matrix for genome sequences
-	//  A  C  G  T	N (or other ambiguous code)
-	//  2 -2 -2 -2 	0	A
-	// -2  2 -2 -2 	0	C
-	// -2 -2  2 -2 	0	G
-	// -2 -2 -2  2 	0	T
-	//	0  0  0  0  0	N (or other ambiguous code)
+    // initialize scoring matrix for genome sequences
+    //  A  C  G  T    N (or other ambiguous code)
+    //  2 -2 -2 -2     0    A
+    // -2  2 -2 -2     0    C
+    // -2 -2  2 -2     0    G
+    // -2 -2 -2  2     0    T
+    //    0  0  0  0  0    N (or other ambiguous code)
     int32_t l, k, m;
-	int8_t* mat = (int8_t*)calloc(25, sizeof(int8_t));
-	for (l = k = 0; l < 4; ++l) {
-		for (m = 0; m < 4; ++m) mat[k++] = l == m ? match : - mismatch;	/* weight_match : -weight_mismatch */
-		mat[k++] = 0; // ambiguous base: no penalty
-	}
-	for (m = 0; m < 5; ++m) mat[k++] = 0;
+    int8_t* mat = (int8_t*)calloc(25, sizeof(int8_t));
+    for (l = k = 0; l < 4; ++l) {
+        for (m = 0; m < 4; ++m) mat[k++] = l == m ? match : - mismatch;    /* weight_match : -weight_mismatch */
+        mat[k++] = 0; // ambiguous base: no penalty
+    }
+    for (m = 0; m < 5; ++m) mat[k++] = 0;
     return mat;
 }
 
 int8_t* gssw_create_nt_table(void) {
     int8_t* ret_nt_table = calloc(128, sizeof(int8_t));
     int8_t nt_table[128] = {
-		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
-		4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
-	};
+        4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
+        4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
+    };
     memcpy(ret_nt_table, nt_table, 128*sizeof(int8_t));
     return ret_nt_table;
 }

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -64,7 +64,10 @@ typedef struct gssw_profile gssw_profile;
 // matrix). F information is not carried over, because gaps in the reference
 // can't span multiple reference nodes.
 typedef struct {
+    // Stores the E values (best gap in read scores) for the *next* column to be
+    // generated, in the matrix to be filled. They are known in advance.
     __m128i* pvE;
+    // Stores the H values (overall best scores) from the previous column, before the matrix to be filled.
     __m128i* pvHStore;
 } gssw_seed;
 

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -759,7 +759,12 @@ void gssw_add_alignment(gssw_multi_align_stack* stack, gssw_alternate_alignment_
     
 /* Retuns the lowest score of an alternate alignment in the stack */
 int16_t gssw_min_alt_alignment_score(gssw_multi_align_stack* stack);
-    
+
+/* Turn on the SSE2 matrix filler (which is on by default) */    
+void gssw_sse2_enable();
+
+/* Turn off the SSE2 matrix filler and use a pure software implementation */
+void gssw_sse2_disable();
     
 #ifdef __cplusplus
 }

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -1,5 +1,5 @@
 /*
- *  ssw.h
+ *  gssw.h
  *
  *  Created by Mengyao Zhao on 6/22/10.
  *  Copyright 2010 Boston College. All rights reserved.
@@ -40,7 +40,7 @@ typedef struct gssw_profile gssw_profile;
 // very best alignment using read characters through j and reference characters
 // through i, no matter what it ends in (match, mismatch, or gap). We also have
 // E[i, j] which gives the score of the best such alignment ending in a gap in
-// the read, and F[i, j], which give sthe score of the best such alignment
+// the read, and F[i, j], which gives the score of the best such alignment
 // ending in a gap in the reference.
 
 // During alignment, we work on one column (i.e. reference character) of all the

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -188,20 +188,20 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
             for (i = 0; i < n1->len; ++i) {
                 // For each column (ref base)
                 
-                if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
-                    "gap in read entries (%d,%d) match", i, j)) {
+                /*if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
+                    "gap in read E entries (%d,%d) match", i, j)) {
                     
                     // Gap in read (E) matrices don't match
                     return 0;
-                }
-                if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
-                    "gap in ref entries (%d,%d) match", i, j)) {
+                }*/
+                /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
+                    "gap in ref F entries (%d,%d) match", i, j)) {
                     
                     // Gap in ref (F) matrices don't match
                     return 0;
-                }
+                }*/
                 if (!check_equal(mH1[i * readLen + j], mH2[i * readLen + j],
-                    "best overall entries (%d,%d) match", i, j)) {\
+                    "best overall H entries (%d,%d) match", i, j)) {\
                     
                     // Main (H) matrices don't match
                     return 0;
@@ -226,20 +226,20 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
             for (i = 0; i < n1->len; ++i) {
                 // For each column (ref base)
                 
-                if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
-                    "gap in read entries (%d,%d) match", i, j)) {
+                /*if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
+                    "gap in read E entries (%d,%d) match", i, j)) {
                     
                     // Gap in read (E) matrices don't match
                     return 0;
-                }
-                if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
-                    "gap in ref entries (%d,%d) match", i, j)) {
+                }*/
+                /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
+                    "gap in ref F entries (%d,%d) match", i, j)) {
                     
                     // Gap in ref (F) matrices don't match
                     return 0;
-                }
+                }*/
                 if (!check_equal(mH1[i * readLen + j], mH2[i * readLen + j],
-                    "best overall entries (%d,%d) match", i, j)) {\
+                    "best overall H entries (%d,%d) match", i, j)) {\
                     
                     // Main (H) matrices don't match
                     return 0;
@@ -346,6 +346,10 @@ void test_gssw_software_fill() {
             check_alignments_match("AAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAA");
         }
         
+        {start_test("should produce identical results on 17 As");
+            check_alignments_match("AAAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAAA");
+        }
+        
         {start_test("should produce identical results on 16 As");
             check_alignments_match("AAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAA");
         }
@@ -354,7 +358,7 @@ void test_gssw_software_fill() {
             char* const reference = "GTGTTCCAGTTCTTATCCTATATCGGAAGTTCAATTATACATCGCACCAGCATATTCATG";
             int32_t i;
             for (i = strlen(reference); i >= 0; i--) {
-                {start_test("should produce identical results on a %d bp string", i);
+                {start_test("should produce identical results on a %d bp string", strlen(reference) - i);
                     check_alignments_match(&reference[i], &reference[i]);
                 }
             }

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -268,12 +268,12 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
             for (i = 0; i < n1->len; ++i) {
                 // For each column (ref base)
                 
-                /*if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
+                if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
                     "gap in read E entries (%d,%d) match", i, j)) {
                     
                     // Gap in read (E) matrices don't match
                     return 0;
-                }*/
+                }
                 /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
                     "gap in ref F entries (%d,%d) match", i, j)) {
                     
@@ -306,12 +306,12 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
             for (i = 0; i < n1->len; ++i) {
                 // For each column (ref base)
                 
-                /*if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
+                if (!check_equal(mE1[i * readLen + j], mE2[i * readLen + j],
                     "gap in read E entries (%d,%d) match", i, j)) {
                     
                     // Gap in read (E) matrices don't match
                     return 0;
-                }*/
+                }
                 /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
                     "gap in ref F entries (%d,%d) match", i, j)) {
                     
@@ -443,6 +443,27 @@ void check_diamond_alignments_match(char* const start, char* const alt1, char* c
  */
 void test_gssw_software_fill() {
     {start_case("The GSSW matrix filler");
+        {start_test("should produce identical results for Jordan's smaller case");
+            char* const ref = "CCCCCCCCCTCCCCCCCCCCT";
+            char* const read = "CCCCCCCTCCCCCCCCCCTCC";
+            
+            check_string_alignments_match(ref, read);
+        
+            
+        }
+    
+        {start_test("should produce identical results for Jordan's diamond");
+            char* const start = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCC";
+            char* const alt1 = "CCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCA";
+            char* const alt2 = "CCCCCACCCCCCCCGTCCCCCCCCCCCA";
+            char* const end = "CCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
+            char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
+            
+            check_diamond_alignments_match(start, alt1, alt2, end, read);
+        
+            
+        }
+    
         {start_test("should produce identical results for a small single-node graph");
             check_string_alignments_match("GATTACA", "GATTTACA");
         }
@@ -508,17 +529,6 @@ void test_gssw_software_fill() {
             check_string_alignments_match(reference, read);
         }
         
-        {start_test("should produce identical results for Jordan's diamond");
-            char* const start = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCC";
-            char* const alt1 = "CCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCA";
-            char* const alt2 = "CCCCCACCCCCCCCGTCCCCCCCCCCCA";
-            char* const end = "CCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
-            char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
-            
-            check_diamond_alignments_match(start, alt1, alt2, end, read);
-        
-            
-        }
     }
         
     

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -33,6 +33,7 @@ int test_results() {
     if (tests_failed) {
         return 1;
     }
+    return 0;
 }
 
 // Has the current test failed?

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -274,12 +274,12 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
                     // Gap in read (E) matrices don't match
                     return 0;
                 }
-                /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
+                if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
                     "gap in ref F entries (%d,%d) match", i, j)) {
                     
                     // Gap in ref (F) matrices don't match
                     return 0;
-                }*/
+                }
                 if (!check_equal(mH1[i * readLen + j], mH2[i * readLen + j],
                     "best overall H entries (%d,%d) match", i, j)) {\
                     
@@ -312,12 +312,12 @@ int check_gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t r
                     // Gap in read (E) matrices don't match
                     return 0;
                 }
-                /*if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
+                if (!check_equal(mF1[i * readLen + j], mF2[i * readLen + j],
                     "gap in ref F entries (%d,%d) match", i, j)) {
                     
                     // Gap in ref (F) matrices don't match
                     return 0;
-                }*/
+                }
                 if (!check_equal(mH1[i * readLen + j], mH2[i * readLen + j],
                     "best overall H entries (%d,%d) match", i, j)) {\
                     
@@ -443,27 +443,6 @@ void check_diamond_alignments_match(char* const start, char* const alt1, char* c
  */
 void test_gssw_software_fill() {
     {start_case("The GSSW matrix filler");
-        {start_test("should produce identical results for Jordan's smaller case");
-            char* const ref = "CCCCCCCCCTCCCCCCCCCCT";
-            char* const read = "CCCCCCCTCCCCCCCCCCTCC";
-            
-            check_string_alignments_match(ref, read);
-        
-            
-        }
-    
-        {start_test("should produce identical results for Jordan's diamond");
-            char* const start = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCC";
-            char* const alt1 = "CCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCA";
-            char* const alt2 = "CCCCCACCCCCCCCGTCCCCCCCCCCCA";
-            char* const end = "CCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
-            char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
-            
-            check_diamond_alignments_match(start, alt1, alt2, end, read);
-        
-            
-        }
-    
         {start_test("should produce identical results for a small single-node graph");
             check_string_alignments_match("GATTACA", "GATTTACA");
         }
@@ -517,6 +496,13 @@ void test_gssw_software_fill() {
             check_string_alignments_match(reference, read);
         }
         
+        {start_test("should produce identical results for Jordan's smaller case");
+            char* const ref = "CCCCCCCCCTCCCCCCCCCCT";
+            char* const read = "CCCCCCCTCCCCCCCCCCTCC";
+            
+            check_string_alignments_match(ref, read);
+        }
+        
         {start_test("should produce identical results for Jordan's edge case");
             char* const reference = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
             char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
@@ -527,6 +513,16 @@ void test_gssw_software_fill() {
             char* const reference = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCACCCCCCCCGTCCCCCCCCCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
             char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
             check_string_alignments_match(reference, read);
+        }
+        
+        {start_test("should produce identical results for Jordan's diamond");
+            char* const start = "CCCCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCC";
+            char* const alt1 = "CCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCA";
+            char* const alt2 = "CCCCCACCCCCCCCGTCCCCCCCCCCCA";
+            char* const end = "CCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
+            char* const read = "CCCCCCCTCCCCCCCCCCTCCCCCCCCCCGACCCCCCCCCCCCCCCCCCCCCACCCCCCCCCCACCCCCCCCCCTCCCACCCCCCCCCCCCGCCCCCCCCCCGCCCCCCCCC";
+            
+            check_diamond_alignments_match(start, alt1, alt2, end, read);
         }
         
     }

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for GSSW.
+ * Not using any real unit testing framework to avoid dependencies.
+ */
+ 
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "gssw.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// Test tools
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Note that a test is starting. Give the name of the thing being tested.
+ * Say something like "MyModule".
+ */
+void start_case(char* const name) {
+    printf("%s...\n", name);
+}
+
+/**
+ * Note that a tert is starting. Say the property being tested.
+ * Say something like "should do the thing".
+ */
+void start_test(char* const property) {
+    printf("\t%s.\n", property);
+}
+
+/**
+ * Make sure the condition is true.
+ */
+void check_condition(int condition, char* const message) {
+    if(condition) {
+        // Test succeeded
+        printf("\t\t[OK] ");
+    } else {
+        // Test failed
+        printf("\t\t[FAIL] ");
+    }
+    
+    printf("%s\n", message);
+    
+    if (!condition) {
+        // Abort the tests at the first failure.
+        exit(1);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GSSW wrappers for easy alignment
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Do a GSSW alignment between the two given strings. Returns a newly allocated
+ * gssw_graph that the caller must destroy with gssw_graph_destroy.
+ */
+gssw_graph* align_strings(char* const ref, char* const read) {
+
+    // default parameters for genome sequence alignment
+    int8_t match = 1, mismatch = 4;
+    uint8_t gap_open = 6, gap_extension = 1;
+
+	/* This table is used to transform nucleotide letters into numbers. */
+    int8_t* nt_table = gssw_create_nt_table();
+    
+	// initialize scoring matrix for genome sequences
+	//  A  C  G  T	N (or other ambiguous code)
+	//  2 -2 -2 -2 	0	A
+	// -2  2 -2 -2 	0	C
+	// -2 -2  2 -2 	0	G
+	// -2 -2 -2  2 	0	T
+	//	0  0  0  0  0	N (or other ambiguous code)
+    int8_t* mat = gssw_create_score_matrix(match, mismatch);
+
+    gssw_node* node;
+    node = gssw_node_create("Node", 1, ref, nt_table, mat);
+    
+    gssw_graph* graph = gssw_graph_create(1);
+    gssw_graph_add_node(graph, node);
+    
+    gssw_graph_fill(graph, read, nt_table, mat, gap_open, gap_extension, 0, 0, 15, 2);
+
+    // Free the translation table
+    free(nt_table);
+    
+    return graph;
+}
+
+/**
+ * Compare score matrices for two filled nodes. Return 1 if they are equal and 0
+ * otherwise.
+ */
+int gssw_node_score_matrices_equal(gssw_node* n1, gssw_node* n2, int32_t readLen) {
+    // Nodes must be the same length
+    if (n1->len != n2->len) {
+        return 0;
+    }
+
+    // Pull out the alignment objects
+    gssw_align* a1 = n1->alignment;
+    gssw_align* a2 = n2->alignment;
+    
+    if (gssw_is_byte(a1) != gssw_is_byte(a2)) {
+        // Both alignments should be the same score size
+        return 0;
+    }
+    
+    if (gssw_is_byte(a1)) {
+        // Compare byte scores
+        // Grab all the matrices
+        uint8_t* mH1 = a1->mH;
+        uint8_t* mE1 = a1->mE;
+        uint8_t* mF1 = a1->mF;
+        
+        uint8_t* mH2 = a2->mH;
+        uint8_t* mE2 = a2->mE;
+        uint8_t* mF2 = a2->mF;
+        
+        int32_t j;
+        for (j = 0; j < readLen; ++j) {
+            // For each row (read base)
+            int32_t i;
+            for (i = 0; i < n1->len; ++i) {
+                // For each column (ref base)
+                
+                if (mH1[i * readLen + j] != mH2[i * readLen + j]) {
+                    // Main (H) matrices don't match
+                    return 0;
+                }
+                if (mE1[i * readLen + j] != mE2[i * readLen + j]) {
+                    // Gap in read (E) matrices don't match
+                    return 0;
+                }
+                if (mF1[i * readLen + j] != mF2[i * readLen + j]) {
+                    // Gap in ref (F) matrices don't match
+                    return 0;
+                }
+            }
+        }
+    } else {
+        // Compare word scores
+        // Grab all the matrices
+        uint16_t* mH1 = a1->mH;
+        uint16_t* mE1 = a1->mE;
+        uint16_t* mF1 = a1->mF;
+        
+        uint16_t* mH2 = a2->mH;
+        uint16_t* mE2 = a2->mE;
+        uint16_t* mF2 = a2->mF;
+        
+        int32_t j;
+        for (j = 0; j < readLen; ++j) {
+            // For each row (read base)
+            int32_t i;
+            for (i = 0; i < n1->len; ++i) {
+                // For each column (ref base)
+                
+                if (mH1[i * readLen + j] != mH2[i * readLen + j]) {
+                    // Main (H) matrices don't match
+                    return 0;
+                }
+                if (mE1[i * readLen + j] != mE2[i * readLen + j]) {
+                    // Gap in read (E) matrices don't match
+                    return 0;
+                }
+                if (mF1[i * readLen + j] != mF2[i * readLen + j]) {
+                    // Gap in ref (F) matrices don't match
+                    return 0;
+                }
+            }
+        }
+    }
+    
+    // If we can't find a mismatch, we say they match
+    return 1;
+    
+}
+
+/**
+ * Compare the score matrices for two filled graphs. Return 1 if they are equal
+ * and 0 otherwise.
+ */
+int gssw_graph_score_matrices_equal(gssw_graph* g1, gssw_graph* g2, int32_t readLen) {
+    if (g1->size != g2->size) {
+        // Different graph sizes/shapes
+        return 0;
+    }
+    
+    uint32_t i = 0;
+    for (i = 0; i < g1->size; i++) {
+        gssw_node* n1 = g1->nodes[i];
+        gssw_node* n2 = g2->nodes[i];
+        
+        if (!gssw_node_score_matrices_equal(n1, n2, readLen)) {
+            // We had a mismatch between these nodes
+            return 0;
+        }
+    }
+    
+    // If we get here, everything matched.
+    return 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test cases
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Test case to make sure that we get the same results from the hardware and
+ * software fillers.
+ */
+void test_gssw_software_fill() {
+    {start_case("The GSSW matrix filler");
+        {start_test("should produce identical results for a small single-node graph");
+        
+            // Define what to align
+            char* const reference = "GATTACA";
+            char* const read = "GATTTACA";
+            
+            // Do the alignment in SSE2 mode
+            gssw_sse2_enable();
+            gssw_graph* sse2_aligned = align_strings(reference, read);
+            // And in software mode
+            gssw_sse2_disable();
+            gssw_graph* software_aligned = align_strings(reference, read);
+            
+            // Now make sure the matrices match
+            check_condition(gssw_graph_score_matrices_equal(sse2_aligned, software_aligned, strlen(read)),
+                "score matrices are identical");
+        }
+        
+        {start_test("should produce identical results for a larger single-node graph with more differences");
+            // Define what to align
+            char* const reference = "GTGTTCCAGTTCTTATCCTATATCGGAAGTTCAATTATACATCGCACCAGCATATTCATG";
+            char* const read = "GTGTTCAAGTTCATCGGAAGTTCAATTCTACATCGCACCAGCATATAAGATAAATTTCTTG";
+            
+            // Do the alignment in SSE2 mode
+            gssw_sse2_enable();
+            gssw_graph* sse2_aligned = align_strings(reference, read);
+            // And in software mode
+            gssw_sse2_disable();
+            gssw_graph* software_aligned = align_strings(reference, read);
+            
+            // Now make sure the matrices match
+            check_condition(gssw_graph_score_matrices_equal(sse2_aligned, software_aligned, strlen(read)),
+                "score matrices are identical");
+        }
+    }
+        
+    
+    
+}
+
+int main (int argc, char * const argv[]) {
+    
+    // Run all the tests
+    test_gssw_software_fill();
+
+    // Success!
+    return 0;
+}
+ 

--- a/src/gssw_test.c
+++ b/src/gssw_test.c
@@ -14,8 +14,29 @@
 // Test tools (basically all printf-like)
 ////////////////////////////////////////////////////////////////////////////////
 
-// Did any tests fail yet?
+// Did any tests fail? If so, how many?
 int tests_failed = 0;
+// How many tests have run?
+int tests_run = 0;
+
+/**
+ * Print the result report an dprovide the return code for main.
+ */
+int test_results() {
+    if (tests_failed) {
+        printf("!!!FAILURE!!!\n");
+    } else {
+        printf("+++SUCCESS+++\n");
+    }
+    printf("Ran %d tests with %d failures.\n", tests_run, tests_failed);
+
+    if (tests_failed) {
+        return 1;
+    }
+}
+
+// Has the current test failed?
+int test_current_failed = 0;
 
 /**
  * Note that a test is starting. Give the name of the thing being tested.
@@ -50,6 +71,12 @@ void start_test(char* const fmt, ...) {
 	vprintf(fmt, argp);
 	printf(".\n");
     va_end(argp);
+    
+    // Say we're runn ing a test
+    tests_run++;
+    
+    // Reset the test failure flag.
+    test_current_failed = 0;
 }
 
 /**
@@ -60,9 +87,12 @@ void vcheck_fail(char* const fmt, va_list argp) {
     printf("\t\t[FAIL] ");
     vprintf(fmt, argp);
     printf("\n");
-        
-    // Don't abort this test yet; continue until the next test.
-    tests_failed = 1;
+    
+    if (!test_current_failed) {
+        // This made the test fail
+        test_current_failed = 1;
+        tests_failed++;
+    }
 }
 
 /**
@@ -500,7 +530,7 @@ int main (int argc, char * const argv[]) {
     // Run all the tests
     test_gssw_software_fill();
 
-    // Return 0 if they succeeded, and 1 otherwise.
-    return tests_failed;
+    // Report result
+    return test_results();
 }
  


### PR DESCRIPTION
This should fix #8.

I have added a pure-software, SSE-intrinsic-free, un-striped matrix filler, and tests to compare its results against the SSE2 results.

I've also modified the SSE2 martrix filler to be less lazy, and to fully compute the E and F matrices (allowing for back to back gaps), with as many lazy F loops as are required to actually get the correct matrix values (instead of just as many as are needed for the best alignment).