### PR TITLE
Fix bug in alternate traceback algorithm

### DIFF
--- a/src/gssw.c
+++ b/src/gssw.c
@@ -2078,6 +2078,8 @@ gssw_cigar* gssw_alignment_trace_back_byte (gssw_node* node,
     int32_t i = *refEnd;
     int32_t j = *readEnd;
     
+    fprintf(stderr, "at entering node traceback, ref end = %d, read end = %d\n", i, j);
+    
     // These let us know if we're currently supposed to be in a gap, waiting for
     // the gap open that ought to open it.
     int32_t gRead = *readGapFlag; // If set we're in E actually
@@ -2733,7 +2735,7 @@ gssw_cigar* gssw_alignment_trace_back_byte (gssw_node* node,
                     int k;
                     for (k = 0; k < node->count_prev; k++) {
                         gssw_node* prev_node = node->prev[k];
-                        source_score = ((uint8_t*) prev_node->alignment->mH)[readLen * (prev_node->len-1) + i - 1];
+                        source_score = ((uint8_t*) prev_node->alignment->mH)[readLen * (prev_node->len - 1) + j - 1];
                         score_diff = scoreHere - source_score;
                         
                         if (UNLIKELY(*deflection_idx == alignment_deflections->num_deflections &&
@@ -3499,12 +3501,12 @@ gssw_cigar* gssw_alignment_trace_back_word (gssw_node* node,
                     int k;
                     for (k = 0; k < node->count_prev; k++) {
                         gssw_node* prev_node = node->prev[k];
-                        source_score = ((uint16_t*) prev_node->alignment->mH)[readLen * (prev_node->len-1) + i - 1];
+                        source_score = ((uint16_t*) prev_node->alignment->mH)[readLen * (prev_node->len - 1) + j - 1];
                         score_diff = scoreHere - source_score;
                         
                         if (UNLIKELY(*deflection_idx == alignment_deflections->num_deflections &&
                                      score_diff < alignment_deflections->score &&
-                                     source_score > 0 && find_internal_node_alts)) {
+                                     source_score > 0)) {
                             // score is suboptimal or we have already chosen an optimal trace and the alternate alignment
                             // does not involve any negative or 0 scores (these are not actually extensions of a local alignment)
                             uint16_t alt_score = alignment_deflections->score - score_diff;
@@ -4011,6 +4013,9 @@ gssw_graph_mapping** gssw_graph_trace_back_internal (gssw_graph* graph,
                                     break;
                             }
                         }
+#ifdef DEBUG_TRACEBACK
+                        fprintf(stderr, "Score at deflected position is %d\n", score);
+#endif
                         deflection_idx++;
                     }
                 }
@@ -4595,6 +4600,7 @@ gssw_graph_mapping** gssw_graph_trace_back_internal (gssw_graph* graph,
         
 #ifdef DEBUG_TRACEBACK
         fprintf(stderr, "at end of traceback loop\n");
+        gssw_print_graph_mapping(gm, stderr);
 #endif
         gssw_reverse_graph_cigar(gc);
         
@@ -5921,7 +5927,7 @@ void gssw_add_alignment(gssw_multi_align_stack* stack, gssw_alternate_alignment_
         }
     }
 #ifdef DEBUG_TRACEBACK
-    fprintf(stderr, "###\n###finished updating alignment stack, scores are now: ");
+    fprintf(stderr, "finished updating alignment stack, scores are now: ");
     if (stack->top_scoring) {
         gssw_multi_align_stack_node* n = stack->top_scoring;
         fprintf(stderr, "%d", n->alt_alignment->score);

--- a/src/gssw.c
+++ b/src/gssw.c
@@ -2078,8 +2078,6 @@ gssw_cigar* gssw_alignment_trace_back_byte (gssw_node* node,
     int32_t i = *refEnd;
     int32_t j = *readEnd;
     
-    fprintf(stderr, "at entering node traceback, ref end = %d, read end = %d\n", i, j);
-    
     // These let us know if we're currently supposed to be in a gap, waiting for
     // the gap open that ought to open it.
     int32_t gRead = *readGapFlag; // If set we're in E actually


### PR DESCRIPTION
Had a bug when there was an alternate alignment that took a match/mismatch over a node boundary. Fixed it.