### PR TITLE
Update to interface in pinning algorithm

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -14,6 +14,12 @@
 
 //	Align a pair of genome sequences.
 int main (int argc, char * const argv[]) {
+    
+    if (argc != 6) {
+        fprintf(stderr, "usage: gssw_example nodeseq1 nodeseq2 nodeseq3 nodeseq4 readseq\n");
+        exit(1);
+    }
+    
     // default parameters for genome sequence alignment
     int8_t match = 1, mismatch = 4;
     uint8_t gap_open = 6, gap_extension = 1;
@@ -41,10 +47,10 @@ int main (int argc, char * const argv[]) {
     int8_t* mat = gssw_create_score_matrix(match, mismatch);
 
     gssw_node* nodes[4];
-    nodes[0] = (gssw_node*)gssw_node_create("A", 1, ref_seq_1, nt_table, mat);
-    nodes[1] = (gssw_node*)gssw_node_create("B", 2, ref_seq_2, nt_table, mat);
-    nodes[2] = (gssw_node*)gssw_node_create("C", 3, ref_seq_3, nt_table, mat);
-    nodes[3] = (gssw_node*)gssw_node_create("D", 4, ref_seq_4, nt_table, mat);
+    nodes[0] = (gssw_node*)gssw_node_create(NULL, 1, ref_seq_1, nt_table, mat);
+    nodes[1] = (gssw_node*)gssw_node_create(NULL, 2, ref_seq_2, nt_table, mat);
+    nodes[2] = (gssw_node*)gssw_node_create(NULL, 3, ref_seq_3, nt_table, mat);
+    nodes[3] = (gssw_node*)gssw_node_create(NULL, 4, ref_seq_4, nt_table, mat);
     
     // makes a diamond
     gssw_nodes_add_edge(nodes[0], nodes[1]);
@@ -76,9 +82,14 @@ int main (int argc, char * const argv[]) {
     gssw_graph_mapping_destroy(gm);
     
     
+    gssw_node** pinning_nodes = (gssw_node**) malloc(sizeof(gssw_node*));
+    pinning_nodes[0] = nodes[3];
+    
     gssw_graph_mapping* gmp = gssw_graph_trace_back_pinned (graph,
                                                             read_seq,
                                                             strlen(read_seq),
+                                                            pinning_nodes,
+                                                            1,
                                                             nt_table,
                                                             mat,
                                                             gap_open,
@@ -90,11 +101,14 @@ int main (int argc, char * const argv[]) {
     gssw_graph_mapping_destroy(gmp);
     
     int num_alts = 15;
+    
     gssw_graph_mapping** gmps = gssw_graph_trace_back_pinned_multi (graph,
                                                                     num_alts,
                                                                     1,
                                                                     read_seq,
                                                                     strlen(read_seq),
+                                                                    pinning_nodes,
+                                                                    1,
                                                                     nt_table,
                                                                     mat,
                                                                     gap_open,
@@ -109,6 +123,7 @@ int main (int argc, char * const argv[]) {
     }
 
     free(gmps);
+    free(pinning_nodes);
     
     gssw_graph_fill(graph, read_seq, nt_table, mat, gap_open, gap_extension, 10, 10, 15, 2, true);
     gssw_graph_print_score_matrices(graph, read_seq, strlen(read_seq), stdout);

--- a/src/example_adj.c
+++ b/src/example_adj.c
@@ -101,10 +101,14 @@ int main (int argc, char * const argv[]) {
     gssw_print_graph_mapping(gm, stdout);
     gssw_graph_mapping_destroy(gm);
     
+    gssw_node** pinning_nodes = (gssw_node**) malloc(sizeof(gssw_node*));
+    pinning_nodes[0] = nodes[3];
     gssw_graph_mapping* gmp = gssw_graph_trace_back_pinned_qual_adj (graph,
                                                                      read_seq,
                                                                      read_qual,
                                                                      strlen(read_seq),
+                                                                     pinning_nodes,
+                                                                     1,
                                                                      nt_table,
                                                                      adj_mat,
                                                                      gap_open,
@@ -122,6 +126,8 @@ int main (int argc, char * const argv[]) {
                                                                              read_seq,
                                                                              read_qual,
                                                                              strlen(read_seq),
+                                                                             pinning_nodes,
+                                                                             1,
                                                                              nt_table,
                                                                              adj_mat,
                                                                              gap_open,
@@ -136,6 +142,7 @@ int main (int argc, char * const argv[]) {
     }
     
     free(gmps);
+    free(pinning_nodes);
     
     // note that nodes which are referred to in this graph are destroyed as well
     gssw_graph_destroy(graph);

--- a/src/example_adj.c
+++ b/src/example_adj.c
@@ -22,6 +22,12 @@ void remove_phred_offset(char* qual_str) {
 
 //	Align a pair of genome sequences.
 int main (int argc, char * const argv[]) {
+    
+    if (argc != 7) {
+        fprintf(stderr, "usage: gssw_example_adj nodeseq1 nodeseq2 nodeseq3 nodeseq4 readseq qualstr\n");
+        exit(1);
+    }
+    
     // default parameters for genome sequence alignment
     int8_t match = 1, mismatch = 4, gap_open = 6, gap_extension = 1;
     // from Mengyao's example about the importance of using all three matrices in traceback.

--- a/src/gssw.h
+++ b/src/gssw.h
@@ -504,10 +504,12 @@ gssw_graph_mapping* gssw_graph_trace_back_qual_adj (gssw_graph* graph,
                                                     int8_t end_full_length_bonus);
 
 // Computes the traceback ending with the final character of the read aligned to the final character
-// of a given node
+// of any of a set of given nodes (which is taken to be allå sink nodes if no set is provided)
 gssw_graph_mapping* gssw_graph_trace_back_pinned (gssw_graph* graph,
                                                   const char* read,
                                                   int32_t readLen,
+                                                  gssw_node** pinning_nodes,
+                                                  int32_t num_pinning_nodes,
                                                   int8_t* nt_table,
                                                   int8_t* score_matrix,
                                                   uint8_t gap_open,
@@ -519,6 +521,8 @@ gssw_graph_mapping* gssw_graph_trace_back_pinned_qual_adj (gssw_graph* graph,
                                                            const char* read,
                                                            const char* qual,
                                                            int32_t readLen,
+                                                           gssw_node** pinning_nodes,
+                                                           int32_t num_pinning_nodes,
                                                            int8_t* nt_table,
                                                            int8_t* adj_score_matrix,
                                                            uint8_t gap_open,
@@ -527,12 +531,15 @@ gssw_graph_mapping* gssw_graph_trace_back_pinned_qual_adj (gssw_graph* graph,
                                                            int8_t end_full_length_bonus);
 
 // Computes an arbitrary number of highest scoring tracebacks ending with the final character of the
-// read aligned to the final character of a given node
+// read aligned to the final character of of any of a set of given nodes (which is taken to be all
+// sink nodes if no set is provided)
 gssw_graph_mapping** gssw_graph_trace_back_pinned_multi (gssw_graph* graph,
                                                          int32_t num_tracebacks,
                                                          int32_t find_internal_node_alts,
                                                          const char* read,
                                                          int32_t readLen,
+                                                         gssw_node** pinning_nodes,
+                                                         int32_t num_pinning_nodes,
                                                          int8_t* nt_table,
                                                          int8_t* score_matrix,
                                                          uint8_t gap_open,
@@ -546,6 +553,8 @@ gssw_graph_mapping** gssw_graph_trace_back_pinned_qual_adj_multi (gssw_graph* gr
                                                                   const char* read,
                                                                   const char* qual,
                                                                   int32_t readLen,
+                                                                  gssw_node** pinning_nodes,
+                                                                  int32_t num_pinning_nodes,
                                                                   int8_t* nt_table,
                                                                   int8_t* adj_score_matrix,
                                                                   uint8_t gap_open,


### PR DESCRIPTION
I uncovered some shortcomings in the pinned alignment interface, specifically with the heuristic of pinning to all sink nodes. Turns out that this can force the alignment to take an indel that it would be otherwise not inclined to in some cases. I'm circumventing the problem by providing the option for the calling environment to specify pinning points rather than having gssw choose them automatically.